### PR TITLE
fix: no more globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Neovim (lua) plugin for working with a text-based, markdown [zettelkasten](https://takesmartnotes.com/) / Wiki and mixing it with a journal, based on [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
 
-Find notes by name, daily and weekly notes by date, search within all notes, place and follow links to your notes or create new ones, with templates.  Current daily and weekly notes are (optionally) created if not present when searching for dailies or weeklies.  Following a link to a non-existing note can also create the missing note (optional). 
+Find notes by name, daily and weekly notes by date, search within all notes, place and follow links to your notes or create new ones, with templates.  Current daily and weekly notes are (optionally) created if not present when searching for dailies or weeklies.  Following a link to a non-existing note can also create the missing note (optional).
 
-Telekasten.nvim can optionally plug into [calendar-vim](https://github.com/mattn/calendar-vim): Selecting a day in the calendar will open up a telescope search with preview that lets you open the daily note (or cancel out and keep browsing your calendar). The daily note  will be created if it doesn't exist.  Days with daily notes get marked in the calendar. 
+Telekasten.nvim can optionally plug into [calendar-vim](https://github.com/mattn/calendar-vim): Selecting a day in the calendar will open up a telescope search with preview that lets you open the daily note (or cancel out and keep browsing your calendar). The daily note  will be created if it doesn't exist.  Days with daily notes get marked in the calendar.
 
 After having written the infamous [sublime_zk](https://github.com/renerocksai/sublime_zk) for SublimeText, having moved on to my standalone [sublimeless_zk](https://github.com/renerocksai/sublimeless_zk), having tried [Roam Research](https://roamresearch.com) and [Obsidian.md](https://obsidian.md) (which I still use sparingly), I have eventually arrived back at the editor I feel at home the most: Neovim 😄! I can literally **live** inside of nvim now, not only for writing code.
 
@@ -18,7 +18,7 @@ This is the result of my first days of hacking neovim with lua:
 
 ## Search-based navigation
 
-Every navigation action, like following a link, is centered around a Telescope search: a Telescope search popup is opened, and in the case of following a link, the search-text is pre-filled with the target.  So, instead of opening the linked note, you get a preview in Telescope and can decide if you actually want to go there. Since the search is often likely to show up more than one result, you can preview related notes immediately. 
+Every navigation action, like following a link, is centered around a Telescope search: a Telescope search popup is opened, and in the case of following a link, the search-text is pre-filled with the target.  So, instead of opening the linked note, you get a preview in Telescope and can decide if you actually want to go there. Since the search is often likely to show up more than one result, you can preview related notes immediately.
 
 ### The preview is a powerful feature
 Leaving the opening of the note to Telescope, you can decide with one keypress whether you want to open the note in a split or in the current window - or if you've seen enough.
@@ -28,7 +28,7 @@ I find that pressing the enter key to confirm the search does not interrupt my f
 ## Install and setup
 
 
-### 0. Prerequisites 
+### 0. Prerequisites
 
 #### Telescope
 Since this plugin uses [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim), you need to install it first.
@@ -36,7 +36,7 @@ Since this plugin uses [telescope.nvim](https://github.com/nvim-telescope/telesc
 [Neovim (v0.5.1)](https://github.com/neovim/neovim/releases/tag/v0.5.1) or the latest neovim nighly commit is required for `telescope.nvim` to work.
 
 #### Ripgrep
-For proper sort order of daily notes, the `rg` executable ([Ripgrep](https://github.com/BurntSushi/ripgrep)) is required and needs to be installed so that nvim can find it. So make sure it's in your path. 
+For proper sort order of daily notes, the `rg` executable ([Ripgrep](https://github.com/BurntSushi/ripgrep)) is required and needs to be installed so that nvim can find it. So make sure it's in your path.
 
 If rg isn't found at `setup()` time, it will not be used. In that case, the sort order of daily and weekly notes are likely to be reversed or total garbage. I do accept pull requests, though, for a lua implementation 😁!
 
@@ -44,7 +44,7 @@ If you can't use `rg`, I recommend using `goto_today()` and `goto_thisweek()` in
 
 #### calendar-vim Plugin (optional)
 
-Telekasten.nvim can optionally plug into [calendar-vim](https://github.com/mattn/calendar-vim): Selecting a day in the calendar will open up a telescope search with preview that lets you open the daily note (or cancel out). The daily note  will be created if it doesn't exist.  Days with daily notes get marked in the calendar. 
+Telekasten.nvim can optionally plug into [calendar-vim](https://github.com/mattn/calendar-vim): Selecting a day in the calendar will open up a telescope search with preview that lets you open the daily note (or cancel out). The daily note  will be created if it doesn't exist.  Days with daily notes get marked in the calendar.
 
 See below for installing and using it.
 
@@ -70,7 +70,7 @@ Somewhere in your vim config, put a snippet like this:
 lua << END
 local home = vim.fn.expand("~/zettelkasten")
 require('telekasten').setup({
-    home         = home
+    home         = home,
     dailies      = home .. '/' .. 'daily',
     weeklies     = home .. '/' .. 'weekly',
     templates    = home .. '/' .. 'templates',
@@ -104,7 +104,7 @@ require('telekasten').setup({
 END
 ```
 | setting | description | example |
-| --- | --- | --- | 
+| --- | --- | --- |
 | `home` | path to your zettelkasten folder (folder with markdown files) | ~/zettelkasten |
 | `dailies` | path where your daily notes go | ~/zettelkasten/daily |
 | `weeklies` | path where your weekly notes go | ~/zettelkasten/weekly |
@@ -113,27 +113,27 @@ END
 | `follow_creates_nonexisting` | following a link to a non-existing note will create it | true |
 | `dailies_create_nonexisting` | following a link to a non-existing daily note will create it | true |
 | `weekly_create_nonexisting` | following a link to a non-existing weekly note will create it | true |
-| `template_new_note` | markdown template for new notes | ~/zettelkasten/templates/new_note.md | 
-| `template_new_daily` | markdown template for new daily notes | ~/zettelkasten/templates/daily.md | 
-| `template_new_weekly` | markdown template for new weekly notes | ~/zettelkasten/templates/weekly.md | 
-| `plug_into_calendar` | activate calendar support if true (needs calendar-vim plugin) | true | 
-| `calendar_opts` | options for calendar, see below | see below | 
+| `template_new_note` | markdown template for new notes | ~/zettelkasten/templates/new_note.md |
+| `template_new_daily` | markdown template for new daily notes | ~/zettelkasten/templates/daily.md |
+| `template_new_weekly` | markdown template for new weekly notes | ~/zettelkasten/templates/weekly.md |
+| `plug_into_calendar` | activate calendar support if true (needs calendar-vim plugin) | true |
+| `calendar_opts` | options for calendar, see below | see below |
 
 The calendar support has its own options, contained in `calendar_opts`:
 
 | calendar setting | description | example |
-| --- | --- | --- | 
-| `weeknm` | calendar week display mode | 1 | 
-|          | 1 .. 'WK01' | | 
-|          | 2 .. 'WK 1' | | 
-|          | 3 .. 'KW01' | | 
-|          | 4 .. 'KW 1' | | 
-|          | 5 .. '1' | | 
-| `calendar_monday` | use monday as start of week if 1 | 1 | 
-| `calendar_mark` | where to put marks to mark days with daily notes | 'left-fit' | 
-|                 | 'left' : ugly | | 
-|                 | 'left-fit' : mark to the left of the day| | 
-|                 | 'right' : mark to the right of the day| | 
+| --- | --- | --- |
+| `weeknm` | calendar week display mode | 1 |
+|          | 1 .. 'WK01' | |
+|          | 2 .. 'WK 1' | |
+|          | 3 .. 'KW01' | |
+|          | 4 .. 'KW 1' | |
+|          | 5 .. '1' | |
+| `calendar_monday` | use monday as start of week if 1 | 1 |
+| `calendar_mark` | where to put marks to mark days with daily notes | 'left-fit' |
+|                 | 'left' : ugly | |
+|                 | 'left-fit' : mark to the left of the day| |
+|                 | 'right' : mark to the right of the day| |
 
 
 ### 3. Configure your own colors
@@ -157,7 +157,7 @@ hi tkBrackets ctermfg=gray
 hi tkLink ctermfg=72 cterm=bold,underline
 hi tkBrackets ctermfg=gray
 
-" highlight ==highlighted== text 
+" highlight ==highlighted== text
 hi tkHighlight ctermbg=yellow ctermfg=darkred cterm=bold
 ```
 
@@ -179,7 +179,7 @@ The plugin defines the following functions.
 - `show_calendar()` : opens up the calendar in a properly-sized vertical split at the very right
 - `setup(opts)`: used for configuring paths, file extension, etc.
 
-To use one of the functions above, just run them with the `:lua ...` command.  
+To use one of the functions above, just run them with the `:lua ...` command.
 
 ```vim
 :lua require("telekasten").find_daily_notes()
@@ -266,7 +266,7 @@ When invoking `show_calendar()`, a calendar showing the previous, current, and n
 - pressing enter on a day will open up a telescope finder with the associated daily note selected and previewed. The daily note will be created if it doesn't exist. If you choose to not open the note, you will return to the calender so you can preview other notes.
 
 
-## Bind it 
+## Bind it
 Usually, you would set up some key bindings, though:
 
 ```vim
@@ -287,20 +287,19 @@ nnoremap <leader>zc :lua require('telekasten').show_calendar()<CR>
 inoremap <leader>[ <ESC>:lua require('telekasten').insert_link()<CR>
 
 
-" ----- the following are for syntax-coloring [[links]] and ==highlighted text== 
+" ----- the following are for syntax-coloring [[links]] and ==highlighted text==
 " ----- (see the section about coloring in README.md)
 
 " for gruvbox
 hi tkLink ctermfg=72 cterm=bold,underline
 hi tkBrackets ctermfg=gray
 
-" highlight ==highlighted== text 
+" highlight ==highlighted== text
 hi tkHighlight ctermbg=yellow ctermfg=darkred cterm=bold
 ```
 
 ## The hardcoded stuff
 
-Currently, the following things are hardcoded: 
+Currently, the following things are hardcoded:
 - the file naming format for daily note files: `YYYY-MM-DD.ext` (e.g. `2021-11-21.md`)
 - the file naming format for weekly note files: `YYYY-Www.ext` (e.g. `2021-W46.md`)
-

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1,5 +1,6 @@
 local builtin = require "telescope.builtin"
-local actions = require("telescope.actions") local action_state = require "telescope.actions.state"
+local actions = require("telescope.actions")
+local action_state = require "telescope.actions.state"
 
 -- declare locals for the nvim api stuff to avoid more lsp warnings
 local vim = vim
@@ -10,7 +11,7 @@ local vim = vim
 -- ----------------------------------------------------------------------------
 local home = vim.fn.expand("~/zettelkasten")
 
-ZkCfg = {
+local ZkCfg = {
     home         = home,
     dailies      = home .. '/' .. 'daily',
     weeklies     = home .. '/' .. 'weekly',
@@ -123,7 +124,7 @@ end
 --
 -- Select from daily notes
 --
-FindDailyNotes = function(opts)
+local FindDailyNotes = function(opts)
     opts = opts or {}
 
     local today = os.date("%Y-%m-%d")
@@ -147,7 +148,7 @@ end
 --
 -- Select from daily notes
 --
-FindWeeklyNotes = function(opts)
+local FindWeeklyNotes = function(opts)
     opts = opts or {}
 
     local title = os.date("%Y-W%V")
@@ -161,7 +162,7 @@ FindWeeklyNotes = function(opts)
         prompt_title = "Find weekly note",
         cwd = ZkCfg.weeklies,
         find_command = ZkCfg.find_command,
-      })
+    })
 end
 
 
@@ -171,13 +172,11 @@ end
 --
 -- Select from all notes and put a link in the current buffer
 --
-InsertLink = function(opts)
-    opts = opts or {}
+local InsertLink = function(_)
     builtin.find_files({
         prompt_title = "Insert link to note",
         cwd = ZkCfg.home,
-        attach_mappings = function(prompt_bufnr, map)
-            map = map -- get rid of lsp error
+        attach_mappings = function(prompt_bufnr, _)
             actions.select_default:replace(function()
                 actions.close(prompt_bufnr)
                 local selection = action_state.get_selected_entry()
@@ -187,7 +186,7 @@ InsertLink = function(opts)
             return true
         end,
         find_command = ZkCfg.find_command,
-   })
+    })
 end
 
 
@@ -197,7 +196,7 @@ end
 --
 -- find the file linked to by the word under the cursor
 --
-FollowLink = function(opts)
+local FollowLink = function(opts)
     opts = opts or {}
     vim.cmd('normal yi]')
     local title = vim.fn.getreg('"0')
@@ -227,7 +226,7 @@ end
 --
 -- Create and yank a [[link]] from the current note.
 --
-YankLink = function()
+local YankLink = function()
     local title = '[[' .. path_to_linkname(vim.fn.expand('%')) .. ']]'
     vim.fn.setreg('"', title)
     print('yanked ' .. title)
@@ -240,9 +239,7 @@ end
 --
 -- find today's daily note and create it if necessary.
 --
-
-
-GotoToday = function(opts)
+local GotoToday = function(opts)
     opts = opts or calenderinfo_today()
     local word = opts.date or os.date("%Y-%m-%d")
 
@@ -257,8 +254,7 @@ GotoToday = function(opts)
         cwd = ZkCfg.home,
         default_text = word,
         find_command = ZkCfg.find_command,
-        attach_mappings = function(prompt_bufnr, map)
-            map = map -- get rid of lsp error
+        attach_mappings = function(prompt_bufnr, _)
             actions.select_default:replace(function()
                 actions.close(prompt_bufnr)
 
@@ -280,13 +276,12 @@ end
 --
 -- Select from notes
 --
-FindNotes = function(opts)
-    opts = opts or {}
+local FindNotes = function(_)
     builtin.find_files({
         prompt_title = "Find notes by name",
         cwd = ZkCfg.home,
         find_command = ZkCfg.find_command,
-   })
+    })
 end
 
 
@@ -296,9 +291,7 @@ end
 --
 -- find the file linked to by the word under the cursor
 --
-SearchNotes = function(opts)
-    opts = opts or {}
-
+local SearchNotes = function(_)
     builtin.live_grep({
         prompt_title = "Search in notes",
         cwd = ZkCfg.home,
@@ -332,8 +325,7 @@ local function on_create(title)
     })
 end
 
-CreateNote = function(opts)
-    opts = opts or {}
+local CreateNote = function(_)
     vim.ui.input({prompt = 'Title: '}, on_create)
 end
 
@@ -360,8 +352,7 @@ local function on_create_with_template(title)
         prompt_title = "Select template...",
         cwd = ZkCfg.templates,
         find_command = ZkCfg.find_command,
-        attach_mappings = function(prompt_bufnr, map)
-            map = map -- get rid of lsp error
+        attach_mappings = function(prompt_bufnr, _)
             actions.select_default:replace(function()
                 actions.close(prompt_bufnr)
                 local template = ZkCfg.templates .. '/' .. action_state.get_selected_entry().value
@@ -374,8 +365,7 @@ local function on_create_with_template(title)
     })
 end
 
-CreateNoteSelectTemplate = function(opts)
-    opts = opts or {}
+local CreateNoteSelectTemplate = function(_)
     vim.ui.input({prompt = 'Title: '}, on_create_with_template)
 end
 
@@ -386,7 +376,7 @@ end
 --
 -- find this week's weekly note and create it if necessary.
 --
-GotoThisWeek = function(opts)
+local GotoThisWeek = function(opts)
     opts = opts or {}
 
     local title = os.date("%Y-W%V")
@@ -411,7 +401,7 @@ end
 -- --------------
 
 -- return if a daily 'note exists' indicator (sign) should be displayed for a particular day
-CalendarSignDay = function(day, month, year)
+local CalendarSignDay = function(day, month, year)
     local fn = ZkCfg.dailies .. '/' .. string.format('%04d-%02d-%02d', year, month, day) .. ZkCfg.extension
     if file_exists(fn) then
         return 1
@@ -420,10 +410,7 @@ CalendarSignDay = function(day, month, year)
 end
 
 -- action on enter on a specific day: preview in telescope, stay in calendar on cancel, open note in other window on accept
-CalendarAction = function(day, month, year, weekday, dir)
-    -- lsp
-    dir = dir
-
+local CalendarAction = function(day, month, year, weekday, _)
     local today = string.format('%04d-%02d-%02d', year, month, day)
     local opts = {}
     opts.date = today
@@ -436,7 +423,7 @@ CalendarAction = function(day, month, year, weekday, dir)
     GotoToday(opts)
 end
 
-ShowCalendar = function(opts)
+local ShowCalendar = function(opts)
     local defaults = {}
     defaults.cmd = 'CalendarVR'
     defaults.vertical_resize = 1
@@ -449,22 +436,22 @@ ShowCalendar = function(opts)
 end
 
 -- set up calendar integration: forward to our lua functions
-SetupCalendar = function(opts)
+local SetupCalendar = function(opts)
     local defaults = ZkCfg.calendar_opts
     opts = opts or defaults
 
     local cmd = [[
         function! MyCalSign(day, month, year)
-            return luaeval('CalendarSignDay(_A[1], _A[2], _A[3])', [a:day, a:month, a:year])
+            return luaeval('require("telekasten").CalendarSignDay(_A[1], _A[2], _A[3])', [a:day, a:month, a:year])
         endfunction
 
         function! MyCalAction(day, month, year, weekday, dir)
             " day : day
             " month : month
-            " year year 
+            " year year
             " weekday : day of week (monday=1)
             " dir : direction of calendar
-            return luaeval('CalendarAction(_A[1], _A[2], _A[3], _A[4], _A[5])', [a:day, a:month, a:year, a:weekday, a:dir]) 
+            return luaeval('require("telekasten").CalendarAction(_A[1], _A[2], _A[3], _A[4], _A[5])', [a:day, a:month, a:year, a:weekday, a:dir])
         endfunction
 
         function! MyCalBegin()
@@ -492,7 +479,7 @@ end
 --
 -- Overrides config with elements from cfg. See top of file for defaults.
 --
-Setup = function(cfg)
+local Setup = function(cfg)
     cfg = cfg or {}
     for k, v in pairs(cfg) do
         -- merge everything but calendar opts
@@ -533,6 +520,7 @@ local M = {
     yank_notelink = YankLink,
     create_note_sel_template = CreateNoteSelectTemplate,
     show_calendar = ShowCalendar,
+    CalendarSignDay = CalendarSignDay,
+    CalendarAction = CalendarAction,
 }
 return M
-


### PR DESCRIPTION
globals are somewhat harmful and should be avoided if possible. You should probably test if everything still works :)

I suggest you to setup luacheck like we have it in telescope: https://github.com/nvim-telescope/telescope.nvim/blob/master/.luacheckrc
I would also suggest you look into formatting. I suggest https://github.com/JohnnyMorganz/StyLua

Last thing you dont need to do `local vim = vim` just have to setup your lsp correctly ;) This should help (I assume you already have a on_attach fn and capabilities table)

```lua
local function get_lua_runtime()
  local result = {}
  for _, path in pairs(vim.api.nvim_list_runtime_paths()) do
    local lua_path = path .. "/lua"
    local stat = vim.loop.fs_stat(lua_path)
    if stat and stat.type == "directory" then
      result[lua_path] = true
    end
  end

  result[vim.fn.expand("$VIMRUNTIME/lua")] = true
  return result
end

lspconfig.sumneko_lua..setup {
  on_attach = on_attach,
  settings = {
    Lua = {
      telemetry = {
        enable = false,
      },
      runtime = {
        version = "LuaJIT",
        path = vim.split(package.path, ";"),
      },
      diagnostics = {
        enable = true,
        globals = { "vim", "describe", "it", "before_each", "teardown", "pending" },
      },
      workspace = {
        library = get_lua_runtime(),
        maxPreload = 1000,
        preloadFileSize = 1000,
      },
    },
  },
  capabilities = capabilities,
}
```

There is also a similar config here https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#sumneko_lua or you use the [tj](https://github.com/tjdevries/nlua.nvim) which does the setup for you