### PR TITLE
fix: sanitize title input (prevent double extension)

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -473,7 +473,7 @@ local function FollowLink(opts)
 	local search_mode = "files"
 
 	local parts = vim.split(title, "#")
-	local filename = ''
+	local filename = ""
 
 	-- if there is a #
 	if #parts ~= 1 then
@@ -781,6 +781,7 @@ local function CreateNote(_)
 	-- vim.ui.input causes ppl problems - see issue #4
 	-- vim.ui.input({ prompt = "Title: " }, on_create)
 	local title = vim.fn.input("Title: ")
+	title = title:gsub("[" .. M.Cfg.extension .. "]+$", "")
 	if #title > 0 then
 		on_create(title)
 	end
@@ -828,6 +829,7 @@ local function CreateNoteSelectTemplate(_)
 	-- vim.ui.input causes ppl problems - see issue #4
 	-- vim.ui.input({ prompt = "Title: " }, on_create_with_template)
 	local title = vim.fn.input("Title: ")
+	title = title:gsub("[" .. M.Cfg.extension .. "]+$", "")
 	if #title > 0 then
 		on_create_with_template(title)
 	end


### PR DESCRIPTION
This prevents repeating the extension if the user already inputs it with the title of the new note.

Before, if a user titled the new note as `mytitle.md` it would be created as `mytitle.md.md`

Now it is just `mytitle.md`.