### PR TITLE
fix: sanitize filesearch

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -472,6 +472,7 @@ local function FollowLink(opts)
 	opts = opts or {}
 	vim.cmd("normal yi]")
 	local title = vim.fn.getreg('"0')
+	title = title:gsub("^(%[)(.+)(%])$", "%2")
 	local search_mode = "files"
 
 	local parts = vim.split(title, "#")
@@ -581,6 +582,7 @@ end
 local function PreviewImg(_)
 	vim.cmd("normal yi)")
 	local fname = vim.fn.getreg('"0')
+	fname = fname:gsub("^(%[)(.+)(%])$", "%2")
 
 	-- check if fname exists anywhere
 	local fexists = file_exists(M.Cfg.home .. "/" .. fname)
@@ -615,6 +617,7 @@ end
 local function FindFriends()
 	vim.cmd("normal yi]")
 	local title = vim.fn.getreg('"0')
+	title = title:gsub("^(%[)(.+)(%])$", "%2")
 
 	builtin.live_grep({
 		prompt_title = "Notes referencing `" .. title .. "`",
@@ -1017,10 +1020,10 @@ local function Setup(cfg)
 	-- setup extensions to filter for
 	M.Cfg.filter_extensions = cfg.filter_extensions or { M.Cfg.extension }
 
-    -- provide fake filenames for template loading to fail silently if template is configured off
-	M.Cfg.template_new_note = M.Cfg.template_new_note or 'none'
-	M.Cfg.template_new_daily = M.Cfg.template_new_daily or 'none'
-	M.Cfg.template_new_weekly = M.Cfg.template_new_weekly or 'none'
+	-- provide fake filenames for template loading to fail silently if template is configured off
+	M.Cfg.template_new_note = M.Cfg.template_new_note or "none"
+	M.Cfg.template_new_daily = M.Cfg.template_new_daily or "none"
+	M.Cfg.template_new_weekly = M.Cfg.template_new_weekly or "none"
 
 	-- refresh templates
 	M.note_type_templates = {


### PR DESCRIPTION
Using `[[wikilinks]]` notation, if the `find_file` (and similar) commands were called while the cursor was **on the first set** of square brackets, it would return `[filename]` instead of the expected `filename` due to the "yank inside brackets"
https://github.com/renerocksai/telekasten.nvim/blob/4914c9d639581aa24959a22bb0ac3f18b1a3fbc4/lua/telekasten.lua#L471

This would then raise an error as telekasten would be looking for a file called `[filename]` and not `filename`, which in turns will cause an issue with the `create_note`.

This PR removes the square brackets if they are completely surrounding the yanked string (while avoiding issues if the file has some words inside square brackets).

It may still cause an issue if the files are starting and finishing with some bracketed words, but my regex is not that good and this case is improbable. Please improve upon it if you can.

Example
- `[picture] cool_cat_pic`  -> would become `[picture] cool_cat_pic`
- `[file] my new zettel [2021]` -> would unfortunately become `file] my new zettel [2021 `