### PR TITLE
add date offsets for note templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,9 @@ Currently, the following substitutions will be made during new note creation:
 | `{{week}}` | week of the year | 46 |
 | `{{lastweek}}` | prior week of the year | 45 |
 | `{{nextweek}}` | next week of the year | 47 |
+| `{{isoweek}}` | week of the year in iso format | 2021-W46 |
+| `{{lastisoweek}}` | prior week of the year in iso format | 2021-W45 |
+| `{{nextisoweek}}` | next week of the year in iso format| 2021-W47 |
 | `{{year}}` | year | 2021 |
 
 As an example, this is my template for new notes:

--- a/README.md
+++ b/README.md
@@ -637,6 +637,14 @@ Currently, the following substitutions will be made during new note creation:
 | `{{isolastweek}}` | prior week of the year in iso format | 2021-W45 |
 | `{{isonextweek}}` | next week of the year in iso format| 2021-W47 |
 | `{{year}}` | year | 2021 |
+| `{{monday}}` | monday's date | 2021-11-16 |
+| `{{tuesday}}` | tuesday's date | 2021-11-17 |
+| `{{wednesday}}` | wednesday's date | 2021-11-18 |
+| `{{thursday}}` | thursday's date | 2021-11-19 |
+| `{{friday}}` | friday's date | 2021-11-20 |
+| `{{saturday}}` | saturday's date | 2021-11-21 |
+| `{{sunday}}` | sunday's date | 2021-11-22 |
+Note: Sunday will be adjusted by the user's `calendar_monday` preference.
 
 As an example, this is my template for new notes:
 

--- a/README.md
+++ b/README.md
@@ -627,14 +627,14 @@ Currently, the following substitutions will be made during new note creation:
 | --- | --- | --- |
 | `{{title}}` | the title of the note | My new note |
 | `{{date}}` | date in iso format | 2021-11-21 |
-| `{{yesterday}}` | yesterday's date in iso format | 2021-11-20 |
-| `{{tomorrow}}` | tomorrow's date in iso format | 2021-11-22 |
+| `{{prevday}}` | previous day's date in iso format | 2021-11-20 |
+| `{{nextday}}` | next day's date in iso format | 2021-11-22 |
 | `{{hdate}}` | date in long format | Sunday, November 21st, 2021 |
 | `{{week}}` | week of the year | 46 |
-| `{{lastweek}}` | prior week of the year | 45 |
+| `{{prevweek}}` | previous week of the year | 45 |
 | `{{nextweek}}` | next week of the year | 47 |
 | `{{isoweek}}` | week of the year in iso format | 2021-W46 |
-| `{{isolastweek}}` | prior week of the year in iso format | 2021-W45 |
+| `{{isoprevweek}}` | previous week of the year in iso format | 2021-W45 |
 | `{{isonextweek}}` | next week of the year in iso format| 2021-W47 |
 | `{{year}}` | year | 2021 |
 | `{{monday}}` | monday's date | 2021-11-16 |

--- a/README.md
+++ b/README.md
@@ -634,8 +634,8 @@ Currently, the following substitutions will be made during new note creation:
 | `{{lastweek}}` | prior week of the year | 45 |
 | `{{nextweek}}` | next week of the year | 47 |
 | `{{isoweek}}` | week of the year in iso format | 2021-W46 |
-| `{{lastisoweek}}` | prior week of the year in iso format | 2021-W45 |
-| `{{nextisoweek}}` | next week of the year in iso format| 2021-W47 |
+| `{{isolastweek}}` | prior week of the year in iso format | 2021-W45 |
+| `{{isonextweek}}` | next week of the year in iso format| 2021-W47 |
 | `{{year}}` | year | 2021 |
 
 As an example, this is my template for new notes:

--- a/README.md
+++ b/README.md
@@ -617,8 +617,12 @@ Currently, the following substitutions will be made during new note creation:
 | --- | --- | --- |
 | `{{title}}` | the title of the note | My new note |
 | `{{date}}` | date in iso format | 2021-11-21 |
+| `{{yesterday}}` | yesterday's date in iso format | 2021-11-20 |
+| `{{tomorrow}}` | tomorrow's date in iso format | 2021-11-22 |
 | `{{hdate}}` | date in long format | Sunday, November 21st, 2021 |
 | `{{week}}` | week of the year | 46 |
+| `{{lastweek}}` | prior week of the year | 45 |
+| `{{nextweek}}` | next week of the year | 47 |
 | `{{year}}` | year | 2021 |
 
 As an example, this is my template for new notes:

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -667,16 +667,31 @@ that are used for creating new notes.
 
 The following substitutions will be made during new note creation:
 
-+-------------+-----------------------+-----------------------------+
-| specifier   |                       |                             |
-| in template | expands to            | example                     |
-+-------------+-----------------------+-----------------------------+
-| `{{title}}`   | the title of the note | My new note                 |
-| `{{date}}`    | date in iso format    | 2021-11-21                  |
-| `{{hdate}}`   | date in long format   | Sunday, November 21st, 2021 |
-| `{{week}}`    | week of the year      | 46                          |
-| `{{year}}`    | year                  | 2021                        |
-+-------------+-----------------------+-----------------------------+
++-------------------+-----------------------+-----------------------------+
+| specifier         |                       |                             |
+| in template       | expands to            | example                     |
++-------------------+-----------------------+-----------------------------+
+| `{{title}}`       | the title of the note | My new note                 |
+| `{{date}}`        | date in iso format    | 2021-11-21                  |
+| `{{yesterday}}`   | yesterday, iso        | 2021-11-20                  |
+| `{{tomorrow}}`    | tomorrow, iso         | 2021-11-22                  |
+| `{{hdate}}`       | date in long format   | Sunday, November 21st, 2021 |
+| `{{week}}`        | week of the year      | 46                          |
+| `{{lastweek}}`    | prior week            | 45                          |
+| `{{nextweek}}`    | next week             | 47                          |
+| `{{isoweek}}`     | week in iso format    | 2021-46                     |
+| `{{lastisoweek}}` | last week, iso        | 2021-45                     |
+| `{{nextisoweek}}` | next week, iso        | 2021-47                     |
+| `{{year}}`        | year                  | 2021                        |
+| `{{monday}}`      | Monday, iso           | 2021-11-15                  |
+| `{{tuesday}}`     | Tuesday, iso          | 2021-11-16                  |
+| `{{wednesday}}`   | Wednesday, iso        | 2021-11-17                  |
+| `{{thursday}}`    | Thursday, iso         | 2021-11-18                  |
+| `{{friday}}`      | Friday, iso           | 2021-11-19                  |
+| `{{saturday}}`    | Saturday, iso         | 2021-11-20                  |
+| `{{sunday}}`      | Sunday, iso (see note)| 2021-11-21                  |
++-------------------+-----------------------+-----------------------------+
+Note: Sunday is adjusted to match users `calendar_monday` preference.
 
 As an example, this is my template for new notes:
 >

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -667,10 +667,10 @@ that are used for creating new notes.
 
 The following substitutions will be made during new note creation:
 
-+-------------------+-----------------------+-----------------------------+
-| specifier         |                       |                             |
-| in template       | expands to            | example                     |
-+-------------------+-----------------------+-----------------------------+
++-----------------+-----------------------+-----------------------------+
+| specifier       |                       |                             |
+| in template     | expands to            | example                     |
++-----------------+-----------------------+-----------------------------+
 | `{{title}}`       | the title of the note | My new note                 |
 | `{{date}}`        | date in iso format    | 2021-11-21                  |
 | `{{yesterday}}`   | yesterday, iso        | 2021-11-20                  |
@@ -690,8 +690,8 @@ The following substitutions will be made during new note creation:
 | `{{friday}}`      | Friday, iso           | 2021-11-19                  |
 | `{{saturday}}`    | Saturday, iso         | 2021-11-20                  |
 | `{{sunday}}`      | Sunday, iso (see note)| 2021-11-21                  |
-+-------------------+-----------------------+-----------------------------+
-Note: Sunday is adjusted to match users `calendar_monday` preference.
++-----------------+-----------------------+-----------------------------+
+Note: Sunday is adjusted to match the user's `calendar_monday` preference.
 
 As an example, this is my template for new notes:
 >

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -673,15 +673,15 @@ The following substitutions will be made during new note creation:
 +-----------------+-----------------------+-----------------------------+
 | `{{title}}`       | the title of the note | My new note                 |
 | `{{date}}`        | date in iso format    | 2021-11-21                  |
-| `{{yesterday}}`   | yesterday, iso        | 2021-11-20                  |
-| `{{tomorrow}}`    | tomorrow, iso         | 2021-11-22                  |
+| `{{prevday}}`     | previous day, iso     | 2021-11-20                  |
+| `{{nextday}}`     | next day, iso         | 2021-11-22                  |
 | `{{hdate}}`       | date in long format   | Sunday, November 21st, 2021 |
 | `{{week}}`        | week of the year      | 46                          |
-| `{{lastweek}}`    | prior week            | 45                          |
+| `{{prevweek}}`    | previous week         | 45                          |
 | `{{nextweek}}`    | next week             | 47                          |
 | `{{isoweek}}`     | week in iso format    | 2021-46                     |
-| `{{lastisoweek}}` | last week, iso        | 2021-45                     |
-| `{{nextisoweek}}` | next week, iso        | 2021-47                     |
+| `{{isoprevweek}}` | last week, iso        | 2021-45                     |
+| `{{isonextweek}}` | next week, iso        | 2021-47                     |
 | `{{year}}`        | year                  | 2021                        |
 | `{{monday}}`      | Monday, iso           | 2021-11-15                  |
 | `{{tuesday}}`     | Tuesday, iso          | 2021-11-16                  |

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -194,8 +194,14 @@ local monthmap = {
 
 local function calenderinfo_today()
     local dinfo = os.date("*t")
+    local oneday = 24 * 60 * 60 -- hours * days * seconds
+    local oneweek = 7 * oneday
+    local date_format = "%Y-%m-%d"
+    local week_format = "%V"
     local opts = {}
-    opts.date = os.date("%Y-%m-%d")
+    opts.date = os.date(date_format)
+    opts.yesterday = os.date(date_format, os.time() - oneday)
+    opts.tomorrow = os.date(date_format, os.time() + oneday)
     local wday = dinfo.wday - 1
     if wday == 0 then
         wday = 7
@@ -211,7 +217,9 @@ local function calenderinfo_today()
         .. daysuffix(dinfo.day)
         .. ", "
         .. dinfo.year
-    opts.week = os.date("%V")
+    opts.week = os.date(week_format)
+    opts.lastweek = os.date(week_format, os.time() - oneweek)
+    opts.nextweek = os.date(week_format, os.time() + oneweek)
     opts.month = dinfo.month
     opts.year = dinfo.year
     opts.day = dinfo.day
@@ -222,6 +230,10 @@ local function linesubst(line, title, calendar_info)
     local cinfo = calendar_info or calenderinfo_today()
     local substs = {
         date = cinfo.date,
+        yesterday = cinfo.yesterday,
+        tomorrow = cinfo.tomorrow,
+        lastweek = cinfo.lastweek,
+        nextweek = cinfo.nextweek,
         hdate = cinfo.hdate,
         week = cinfo.week,
         year = cinfo.year,

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -260,6 +260,7 @@ local function calenderinfo_today()
         .. dinfo.year
     opts.week = os.date(dateformats.week)
     opts.isoweek = os.date(dateformats.isoweek)
+    opts.month = dinfo.month
     opts.year = dinfo.year
     opts.day = dinfo.day
     return opts
@@ -270,7 +271,7 @@ local function linesubst(line, title, calendar_info, relative_dates)
     local rdates = relative_dates or relativedates_today()
     local substs = {
         date    = cinfo.date,
-        hdate   = cinfo.hdate,
+        hdate   =cinfo.hdate,
         week    = cinfo.week,
         isoweek = cinfo.isoweek,
         year    = cinfo.year,

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -203,6 +203,7 @@ local function calenderinfo_today()
     local oneweek = 7 * oneday
     local date_format = "%Y-%m-%d"
     local week_format = "%V"
+    local isoweek_format = "%Y-W%V"
     local opts = {}
     opts.date = os.date(date_format)
     opts.yesterday = os.date(date_format, os.time() - oneday)
@@ -225,6 +226,9 @@ local function calenderinfo_today()
     opts.week = os.date(week_format)
     opts.lastweek = os.date(week_format, os.time() - oneweek)
     opts.nextweek = os.date(week_format, os.time() + oneweek)
+    opts.week = os.date(isoweek_format)
+    opts.lastisoweek = os.date(isoweek_format, os.time() - oneweek)
+    opts.nextisoweek = os.date(isoweek_format, os.time() + oneweek)
     opts.month = dinfo.month
     opts.year = dinfo.year
     opts.day = dinfo.day


### PR DESCRIPTION
This extends the cinfo (calendar_info) table with yesterday, tomorrow, lastweek, and nextweek values to be used as tokens in templates.