### PR TITLE
fix bug with create_note_from_template and nil calendar_info

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -281,6 +281,11 @@ local function calculate_dates(date)
 end
 
 local function linesubst(line, title, dates)
+    
+    if dates == nil then
+      dates = calculate_dates()
+    end
+
     local substs = {
         hdate = dates.hdate,
         week = dates.week,

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -281,9 +281,8 @@ local function calculate_dates(date)
 end
 
 local function linesubst(line, title, dates)
-    
     if dates == nil then
-      dates = calculate_dates()
+        dates = calculate_dates()
     end
 
     local substs = {


### PR DESCRIPTION
Calling create_note_from_template from follow_link to a nonexistent file throws and error because calendar_info isn't set before calling linesubst.  This adds a check and assumes that if no date information is passed that you want today's dates.
