### PR TITLE
fix: make goto_today() look for daily notes, not zettels

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1494,7 +1494,7 @@ local function GotoDate(opts)
 
     find_files_sorted({
         prompt_title = "Goto day",
-        cwd = M.Cfg.home,
+        cwd = M.Cfg.dailies,
         default_text = word,
         find_command = M.Cfg.find_command,
         attach_mappings = function(prompt_bufnr, map)


### PR DESCRIPTION
Goto_today() should look in the correct directory for daily entries. This is especially important if the journal directory is not a subdirectory of the zettelkasten home directory, as the daily notes were not appearing at all in that case.