### PR TITLE
Fixed day suffix - there's no 33rd, but there is a 23rd

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -218,7 +218,7 @@ local function daysuffix(day)
     if (day == "2") or (day == "22") then
         return "nd"
     end
-    if (day == "3") or (day == "33") then
+    if (day == "3") or (day == "23") then
         return "rd"
     end
     return "th"


### PR DESCRIPTION
The first time I tried to make a daily note was Dec 23rd.  I noticed that my note said 23th, not 23rd.  After investigating, I found this simple typo.  I didn't think it was worth creating an issue over.