### PR TITLE
Windows file path clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ To avoid the most common Windows issue:
 - Second best option: try WSL2 on Windows and pretend you're on Linux
 - if you **must** use Windows, use `/Users/myname/zettelkasten` instead of `~/zettelkasten`
 - **NEVER** use `C:\Users\myname` style paths
+- Using `vim.fn.expand("~/zettelkasten")` should work now but mileage will vary with anything outside of finding and opening files
 
 ```lua
 lua << END
@@ -215,6 +216,7 @@ local home = vim.fn.expand("~/zettelkasten")
 -- - try WSL2 on Windows and pretend you're on Linux
 -- - if you **must** use Windows, use "/Users/myname/zettelkasten" instead of "~/zettelkasten"
 -- - NEVER use "C:\Users\myname" style paths
+-- - Using `vim.fn.expand("~/zettelkasten")` should work now but mileage will vary with anything outside of finding and opening files
 require('telekasten').setup({
     home         = home,
 
@@ -331,6 +333,7 @@ END
 |        | - try WSL2 on Windows and pretend you're on Linux | |
 |        | - if you **must** use Windows, use `/Users/myname/zettelkasten` instead of `~/zettelkasten` | |
 |        | - **NEVER** use `C:\Users\myname` style paths | |
+|        | - Using `vim.fn.expand("~/zettelkasten")` should work now but mileage will vary with anything outside of finding and opening files | |
 | **`take_over_my_home`** | if set to `true` (default), telekasten will take over your home. Any notes from the configured `home` directory will receive a `set filetype=telekasten`, no matter if opened by telekasten or another way. | true |
 | `dailies` | path where your daily notes go | ~/zettelkasten/daily |
 | `weeklies` | path where your weekly notes go | ~/zettelkasten/weekly |

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -16,6 +16,10 @@ daily note (or cancel out and keep browsing your calendar). The daily note
 will be created if it doesn't exist. Days with daily notes get marked in the
 calendar.
 
+For Windows users, many of the functions that require navigating file folders
+do not work. This is due to how Telescope handles paths and the odd way that
+Windows structures its paths. It is advised you don't use Windows.
+
 To find out more:
 https://github.com/renerocksai/telekasten.nvim
 
@@ -137,6 +141,20 @@ telekasten.setup({opts})
         your notes will be stored.
 
         Default: '~/zettelkasten'
+
+        ----------------------
+        Note to Windows users: 
+
+        If you must use Windows, avoid using the drive path. You may use it, 
+        but telekasten will ignore the drive name and create your main markdown
+        / zettelkasten folder in the same drive that neovim executes from. This
+        is because of how Telescope handles files paths. Windows paths must be 
+        stripped of the drive name or else the path will not be read correctly.
+        This is done automatically but is advised that you avoid adding it.
+
+        It is recommended that if your path is not the default to write it
+        like a Unix path with '/' instead of '\', or to escape the '\' as '\\'.
+        ----------------------
 
                                    *telekasten.settings.take_over_my_home*
     take_over_my_home: ~

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -31,9 +31,9 @@ local function CleanPath(path)
     local windows_delim = "\\"
     -- Returns the path delimeter for the machine
     -- '\\' for Windows, '/' for Unix
-    local system_delim = package.config:sub(1,1)
+    local system_delim = package.config:sub(1, 1)
     local new_path_start
-    
+
     -- Removes portion of path before '\\' for Windows machines
     -- since Telescope does not like that
     if system_delim == windows_delim then

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -24,7 +24,7 @@ local Path = require("plenary.path")
 local vim = vim
 
 -- Cleans home path for Windows users
--- Needs to be before default config, else with no use config
+-- Needs to be before default config, else with no user config
 -- home will not be cleaned and issues will still occur
 local function CleanPath(path)
     -- File path delimeter for Windows machines

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -42,7 +42,7 @@ local function CleanPath(path)
             path = path:sub(new_path_start) -- Start path at the first '\\'
         end
     end
-    
+
     -- Returns cleaned path
     return path
 end

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -23,10 +23,35 @@ local Path = require("plenary.path")
 -- declare locals for the nvim api stuff to avoid more lsp warnings
 local vim = vim
 
+-- Cleans home path for Windows users
+-- Needs to be before default config, else with no use config
+-- home will not be cleaned and issues will still occur
+local function CleanPath(path)
+    -- File path delimeter for Windows machines
+    local windows_delim = "\\"
+    -- Returns the path delimeter for the machine
+    -- '\\' for Windows, '/' for Unix
+    local system_delim = package.config:sub(1,1)
+    local new_path_start
+    
+    -- Removes portion of path before '\\' for Windows machines
+    -- since Telescope does not like that
+    if system_delim == windows_delim then
+        new_path_start = path:find(windows_delim) -- Find the first '\\'
+        if new_path_start ~= nil then
+            path = path:sub(new_path_start) -- Start path at the first '\\'
+        end
+    end
+    
+    -- Returns cleaned path
+    return path
+end
+
 -- ----------------------------------------------------------------------------
 -- DEFAULT CONFIG
 -- ----------------------------------------------------------------------------
 local home = vim.fn.expand("~/zettelkasten")
+home = CleanPath(home)
 local M = {}
 
 M.Cfg = {
@@ -2487,6 +2512,8 @@ local function Setup(cfg)
         -- merge everything but calendar opts
         -- they will be merged later
         if k ~= "calendar_opts" then
+            if k == "home" then
+                v = CleanPath(v)
             M.Cfg[k] = v
             if debug then
                 print(

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2514,6 +2514,7 @@ local function Setup(cfg)
         if k ~= "calendar_opts" then
             if k == "home" then
                 v = CleanPath(v)
+            end
             M.Cfg[k] = v
             if debug then
                 print(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

This PR fixes #71. I've added a function called `CleanPath` to `telekasten.lua` that takes the incoming `home` path (either default or set by the user in their config) and checks if it is a Windows path. If not, it returns the original path. If it is, it substitutes the path with a substring of the path that begins at the first folder delimiter (`\\` in Windows, `/` in Unix/Linux).

This change allows Windows users to use `vim.fn.expand('~\zettelkasten')` like in the default config (or any variation of the sort) without having to worry about `C:` messing up the file path.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #71
- This PR is related to issue: #71

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
