### PR TITLE
Allow passing default_text opt to SearchNotes 

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1587,7 +1587,7 @@ local function SearchNotes(opts)
         prompt_title = "Search in notes",
         cwd = M.Cfg.home,
         search_dirs = { M.Cfg.home },
-        default_text = vim.fn.expand("<cword>"),
+        default_text = opts.default_text or vim.fn.expand("<cword>"),
         find_command = M.Cfg.find_command,
         attach_mappings = function(_, map)
             actions.select_default:replace(picker_actions.select_default)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

I want to be able to assign keybindings to specific search text so that I can quickly find kinds of things in my notes.

The first is with TODOs - implemented like this:

`nnoremap <leader>zg :lua require('telekasten').search_notes({default_text=[[- \[ \] ]]})`

I'll be using it for some tags as well and perhaps others might find it useful. 

I'm new to Lua so any feedback would be greatly appreciated. 

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update **(not yet but happy to update wherever is relevant as well)**

## Additional information

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
** will do the rest when I have time later on - not familiar with lua enough to do this quickly right now**
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
Happy to do this later if you'd like to merge.
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
