### PR TITLE
Add UUID prefix to new notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ require('telekasten').setup({
     -- markdown file extension
     extension    = ".md",
 
+    -- prefix file with uuid
+    prefix_title_by_uuid = false,
+    -- file uuid type ("rand" or input for os.date()")
+    uuid_type = "%Y%m%d%H%M",
+
     -- following a link to a non-existing note will create it
     follow_creates_nonexisting = true,
     dailies_create_nonexisting = true,

--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ Currently, the following substitutions will be made during new note creation:
 | specifier in template | expands to | example |
 | --- | --- | --- |
 | `{{title}}` | the title of the note | My new note |
+| `{{uuid}}` | UUID for the note | 202201271129 |
 | `{{date}}` | date in iso format | 2021-11-21 |
 | `{{prevday}}` | previous day's date in iso format | 2021-11-20 |
 | `{{nextday}}` | next day's date in iso format | 2021-11-22 |

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ require('telekasten').setup({
     prefix_title_by_uuid = false,
     -- file uuid type ("rand" or input for os.date()")
     uuid_type = "%Y%m%d%H%M",
+    -- UUID separator
+    uuid_sep = "-",
 
     -- following a link to a non-existing note will create it
     follow_creates_nonexisting = true,

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -68,9 +68,12 @@ telekasten.setup({opts})
       extension    = ".md",
 
       -- prefix file with uuid
-      prefix_title_by_uuid = true,
+      prefix_title_by_uuid = false,
       -- file uuid type ("rand" or input for os.date such as "%Y%m%d%H%M")
       uuid_type = "%Y%m%d%H%M",
+      -- UUID separator
+      uuid_sep = "-",
+
 
       templates = '/path/to/directory',     -- path to templates
       extension = '.file extension',        -- file extension of note files
@@ -199,6 +202,12 @@ telekasten.setup({opts})
         time format to input in os.date() such as %Y%m%d%H%M.
 
         Default: '%Y%m%d%H%M'
+
+                                            *telekasten.settings.uuid_sep*
+    uuid_sep: ~
+        Separator between UUID and title in filaneme.
+
+        Default: '-'
 
                                         *telekasten.settings.image_subdir*
     image_subdir: ~

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -67,6 +67,11 @@ telekasten.setup({opts})
       -- markdown file extension
       extension    = ".md",
 
+      -- prefix file with uuid
+      prefix_title_by_uuid = true,
+      -- file uuid type ("rand" or input for os.date such as "%Y%m%d%H%M")
+      uuid_type = "%Y%m%d%H%M",
+
       templates = '/path/to/directory',     -- path to templates
       extension = '.file extension',        -- file extension of note files
 
@@ -181,6 +186,19 @@ telekasten.setup({opts})
         Filename extension of your markdown note files.
 
         Default: '.md'
+
+                                *telekasten.settings.prefix_title_by_uuid*
+    prefix_title_by_uuid: ~
+        Adds an Universal Unique Identifier before the file name.
+
+        Default: 'false'
+
+                                           *telekasten.settings.uuid_type*
+    uuid_type: ~
+        Type of UUID. Could be 'rand' for a random 6 character string, or a
+        time format to input in os.date() such as %Y%m%d%H%M.
+
+        Default: '%Y%m%d%H%M'
 
                                         *telekasten.settings.image_subdir*
     image_subdir: ~

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -759,6 +759,7 @@ The following substitutions will be made during new note creation:
 | in template     | expands to            | example                     |
 +-----------------+-----------------------+-----------------------------+
 | `{{title}}`       | the title of the note | My new note                 |
+| `{{uuid}}`        | UUID of the note      | 202201271129                |
 | `{{date}}`        | date in iso format    | 2021-11-21                  |
 | `{{prevday}}`     | previous day, iso     | 2021-11-20                  |
 | `{{nextday}}`     | next day, iso         | 2021-11-22                  |

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -52,6 +52,11 @@ M.Cfg = {
     -- markdown file extension
     extension = ".md",
 
+    -- prefix file with uuid
+    prefix_title_by_uuid = false,
+    -- file uuid type ("rand" or input for os.date()")
+    uuid_type = "%Y%m%d%H%M",
+
     -- following a link to a non-existing note will create it
     follow_creates_nonexisting = true,
     dailies_create_nonexisting = true,
@@ -141,6 +146,32 @@ local function file_exists(fname)
     else
         return false
     end
+end
+
+local function random_variable(length)
+    math.randomseed(os.clock() ^ 5)
+    local res = ""
+    for _ = 1, length do
+        res = res .. string.char(math.random(97, 122))
+    end
+    return res
+end
+
+local function append_uuid(opts, title)
+    opts.prefix_title_by_uuid = opts.prefix_title_by_uuid
+        or M.Cfg.prefix_title_by_uuid
+    opts.uuid_type = opts.uuid_type or M.Cfg.uuid_type
+
+    if opts.prefix_title_by_uuid then
+        local uuid = ""
+        if opts.uuid_type ~= "rand" then
+            uuid = os.date(opts.uuid_type)
+        else
+            uuid = random_variable(6)
+        end
+        title = uuid .. "-" .. title
+    end
+    return title
 end
 
 local function print_error(s)
@@ -1793,6 +1824,8 @@ local function on_create_with_template(opts, title)
         return
     end
 
+    title = append_uuid(opts, title)
+
     opts = opts or {}
     opts.insert_after_inserting = opts.insert_after_inserting
         or M.Cfg.insert_after_inserting
@@ -1873,6 +1906,8 @@ local function on_create(opts, title)
     if title == nil then
         return
     end
+
+    title = append_uuid(opts, title)
 
     local pinfo = Pinfo:new({ title = title, opts })
     local fname = pinfo.filepath

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -163,7 +163,7 @@ local function append_uuid(opts, title)
     opts.uuid_type = opts.uuid_type or M.Cfg.uuid_type
 
     if opts.prefix_title_by_uuid then
-        local uuid = ""
+        local uuid
         if opts.uuid_type ~= "rand" then
             uuid = os.date(opts.uuid_type)
         else


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

This allows the user to specify if they want an UUID prefix in the filename of the new notes (`false`by default).
Two types of prefixes are supported:
- `rand`: a random 6-char string
- `<input for os.date()>` such as `%Y%m%d%H%M`(default)


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Related to discussion #56
- 
## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
