### PR TITLE
fix: accents in tags closes #86

### DIFF
--- a/lua/taglinks/tagutils.lua
+++ b/lua/taglinks/tagutils.lua
@@ -1,9 +1,10 @@
 local Job = require("plenary.job")
 
 local M = {}
-local hashtag_re = "(^|\\s|'|\")#[a-zA-Z]+[a-zA-Z0-9/\\-_]*"
-local colon_re = "(^|\\s):[a-zA-Z]+[a-zA-Z0-9/\\-_]*:"
-local yaml_re = "(^|\\s)tags:\\s*\\[([a-zA-Z]+[a-zA-Z0-9/\\-_]*(,\\s)*)*]"
+local hashtag_re = "(^|\\s|'|\")#[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\\-_]*"
+local colon_re = "(^|\\s):[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\\-_]*:"
+local yaml_re =
+    "(^|\\s)tags:\\s*\\[([a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\\-_]*(,\\s)*)*]"
 
 local function command_find_all_tags(opts)
     opts = opts or {}

--- a/syntax/telekasten.vim
+++ b/syntax/telekasten.vim
@@ -11,8 +11,8 @@ syn region Comment matchgroup=Comment start="<!--" end="-->"  contains=tkTag kee
 syntax region tkLink matchgroup=tkBrackets start=/\[\[/ end=/\]\]/ display oneline
 syntax region tkHighlight matchgroup=tkBrackets start=/==/ end=/==/ display oneline
 
-syntax match tkTag "\v#[a-zA-Z]+[a-zA-Z0-9/\-_]*"
-syntax match tkTag "\v:[a-zA-Z]+[a-zA-Z0-9/\-_]*:"
+syntax match tkTag "\v#[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*"
+syntax match tkTag "\v:[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*:"
 
 syntax match tkTagSep "\v\s*,\s*" contained
 syntax region tkTag matchgroup=tkBrackets start=/^tags\s*:\s*\[\s*/ end=/\s*\]\s*$/ contains=tkTagSep display oneline
@@ -28,7 +28,7 @@ let b:current_syntax = 'telekasten'
 "     hi tklink ctermfg=72 cterm=bold,underline
 "     hi tkBrackets ctermfg=gray
 
-" " Highlight ==highlighted== text 
+" " Highlight ==highlighted== text
 "     hi tkHighlight ctermbg=yellow ctermfg=darkred cterm=bold
 "
 " " Tags


### PR DESCRIPTION
## Proposed change
This allows the use of accented characters in the tags. Both tag search and tag highlight have been fixed.

The `[À-ÿ]` regex matches the following characters: `àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜçÇßØøÅåÆæ`, which should cover most cases. 
I think it could still be a good idea to rework it further so we could add full utf-8 support (in case people use Chinese or Russian alphabet, or even emoji maybe).

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #86 
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [ x The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
