### PR TITLE
fix: media links issue, closes #91

### DIFF
--- a/lua/taglinks/taglinks.lua
+++ b/lua/taglinks/taglinks.lua
@@ -9,6 +9,7 @@ M.is_tag_or_link_at = function(line, col, opts)
         and line:sub(1, 4) == "tags"
 
     local seen_bracket = false
+    local seen_parenthesis = false
     local cannot_be_tag = false
 
     while col >= 1 do
@@ -20,8 +21,17 @@ M.is_tag_or_link_at = function(line, col, opts)
             end
         end
 
+        if seen_parenthesis then
+            -- Media link, currently identified by not link nor tag
+            if char == "]" then
+                return nil, nil
+            end
+        end
+
         if char == "[" then
             seen_bracket = true
+        elseif char == "(" then
+            seen_parenthesis = true
         end
 
         if is_tagline == true then


### PR DESCRIPTION
## Proposed change
The current way of determining if an object is a link or a tag is not really great in my opinion. Basically, we start at the cursor, and look left. If the left char is a `[`, we look continue looking left. If it is again a `[`, we assume that the cursor is a zettel link.

There is therefore an issue with media links. These are formed by a pair of `[text](link)`. Starting somewhere in the link, we move left and find the first `[` (before text). If there is nothing else on that line, fine we return nil and assume it was a media link. If however there was an other occurrence of `[` ANYWHERE before that (in a Todo, as in #91, or with a proper wiki link (or any other link), the old routine would assume we are in a zettel link.

The quick fix implemented here just add a check to see if we have a normal parenthesis. If it is, we look for a `]` somewhere on the left. If we find it, we assume we are on a media link and output the expected `nil` values.

This solves the issue effectively without adding more problems. However, I find this approach very very sub-optimal. It may be more robust to reset the `found_bracket` and `found_parenthesis` if the first char on the left does not correspond to a proper link. But then, what are the "proper" ways of writing a link? Would a space be allowed? `[text] (link)` or `[ [zettel] ]`?


## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

- This PR fixes or closes issue: fixes #91 
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x]  There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
