### PR TITLE
fix: follow_links with headerlinks, closes 109

### DIFF
--- a/lua/taglinks/taglinks.lua
+++ b/lua/taglinks/taglinks.lua
@@ -10,6 +10,7 @@ M.is_tag_or_link_at = function(line, col, opts)
 
     local seen_bracket = false
     local seen_parenthesis = false
+    local seen_hashtag = false
     local cannot_be_tag = false
 
     while col >= 1 do
@@ -41,7 +42,11 @@ M.is_tag_or_link_at = function(line, col, opts)
                 end
             end
         else
-            if char == "#" and opts.tag_notation == "#tag" then
+            if char == "#" then
+                seen_hashtag = true
+            end
+            -- Tags should have a space before #, if not we are likely in a link
+            if char == " " and seen_hashtag and opts.tag_notation == "#tag" then
                 if not cannot_be_tag then
                     return "tag", col
                 end


### PR DESCRIPTION
## Proposed change
As discussed in #110, the way telekasten determines if we are in a link or a tag is probably suboptimal.
This PR solves #109 by allowing the user to place the cursor wherever they want when doing follow_link() and not just on the filename part.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109 
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

Yes to all

<!--
  Thank you for contributing <3
-->
