### PR TITLE
Fix UUID when not in filename

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -191,24 +191,20 @@ local function random_variable(length)
 end
 
 local function get_uuid(opts)
-    opts.prefix_title_by_uuid = opts.prefix_title_by_uuid
-        or M.Cfg.prefix_title_by_uuid
     opts.uuid_type = opts.uuid_type or M.Cfg.uuid_type
 
     local uuid
-    if opts.prefix_title_by_uuid then
-        if opts.uuid_type ~= "rand" then
-            uuid = os.date(opts.uuid_type)
-        else
-            uuid = random_variable(6)
-        end
+    if opts.uuid_type ~= "rand" then
+        uuid = os.date(opts.uuid_type)
+    else
+        uuid = random_variable(6)
     end
     return uuid
 end
 
 local function concat_uuid_title(uuid, title)
     local sep = M.Cfg.uuid_sep or "-"
-    if uuid == nil then
+    if uuid == nil or not M.Cfg.prefix_title_by_uuid then
         return title
     else
         return uuid .. sep .. title


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

The uuid was only being created if the title prefix option was set, which meant it couldn't be used in a template.

I'd originally thought that link yanks and link follows worked via searching for the uuid (as seen on zettelkasten.de sample notes), but I see now that it works on note title as implemented. This yields an interesting follow-on question: Is there any reason to ever include the uuid in a template? I had been planning on naming the notes by title, and including uuid in the yaml front matter.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
