### PR TITLE
Improve note filename formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,12 @@ require('telekasten').setup({
     -- markdown file extension
     extension    = ".md",
 
-    -- prefix file with uuid
-    prefix_title_by_uuid = false,
+    -- Generate note filenames. One of:
+    -- "title" (default) - Use title if supplied, uuid otherwise
+    -- "uuid" - Use uuid
+    -- "uuid-title" - Prefix title by uuid
+    -- "title-uuid" - Suffix title with uuid
+    new_note_filename = "title",
     -- file uuid type ("rand" or input for os.date()")
     uuid_type = "%Y%m%d%H%M",
     -- UUID separator

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -71,8 +71,12 @@ telekasten.setup({opts})
       -- markdown file extension
       extension    = ".md",
 
-      -- prefix file with uuid
-      prefix_title_by_uuid = false,
+      -- Generate note filenames. One of:
+      -- "title" (default) - Use title if supplied, uuid otherwise
+      -- "uuid" - Use uuid
+      -- "uuid-title" - Prefix title by uuid
+      -- "title-uuid" - Suffix title with uuid
+      new_note_filename = "title",
       -- file uuid type ("rand" or input for os.date such as "%Y%m%d%H%M")
       uuid_type = "%Y%m%d%H%M",
       -- UUID separator
@@ -210,11 +214,18 @@ telekasten.setup({opts})
 
         Default: '.md'
 
-                                *telekasten.settings.prefix_title_by_uuid*
-    prefix_title_by_uuid: ~
-        Adds an Universal Unique Identifier before the file name.
+                                   *telekasten.settings.new_note_filename*
+    new_note_filename: ~
+        Configures the filenames of newly created notes. See |uuid_sep|
+        for 'uuid-title' and 'title-uuid' separator.
 
-        Default: 'false'
+        Valid options are:
+        - 'title' .. title only
+        - 'uuid' .. uuid only
+        - 'uuid-title' .. prefix title by uuid
+        - 'title-uuid' .. suffix title with uuid
+
+        Default: 'title'
 
                                            *telekasten.settings.uuid_type*
     uuid_type: ~


### PR DESCRIPTION
Provide the user with the choice between:

"title" (default) - Title only
"uuid" - UUID only
"uuid-title" - Title prefixed by UUID
"title-uuid" - Title suffixed with UUID


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->
See discussion in #129 for the rationale behind this change.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #129 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
