### PR TITLE
Feature: Short Title Template Substitutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,32 +112,32 @@ of being able to edit it.
 
 <!-- vim-markdown-toc GFM -->
 
-- [0. Install and setup](#0-install-and-setup)
-  - [0.0 Prerequisites](#00-prerequisites)
-    - [0.0.1 Telescope](#001-telescope)
-    - [0.0.2 calendar-vim Plugin (optional)](#002-calendar-vim-plugin-optional)
-    - [0.0.3 For pasting images: xclip (optional)](#003-for-pasting-images-xclip-optional)
-    - [0.0.4 For image previews: telescope-media-files.nvim (optional)](#004-for-image-previews-telescope-media-filesnvim-optional)
-      - [catimg](#catimg)
-      - [viu](#viu)
-      - [telescope-media-files.nvim](#telescope-media-filesnvim)
-  - [0.1 Install the plugin](#01-install-the-plugin)
-    - [0.1.0 Other useful plugins](#010-other-useful-plugins)
-  - [0.2 Configure telekasten.nvim](#02-configure-telekastennvim)
-  - [0.3 Configure your own colors](#03-configure-your-own-colors)
-- [1. Get Help](#1-get-help)
-- [2. Use it](#2-use-it)
-  - [2.0 Telekasten command](#20-telekasten-command)
-  - [2.1 Telekasten command palette](#21-telekasten-command-palette)
-  - [2.2 Telekasten lua functions](#22-telekasten-lua-functions)
-  - [2.3 Link notation](#23-link-notation)
-  - [2.4 Tag notation](#24-tag-notation)
-  - [2.5 Note templates](#25-note-templates)
-    - [2.5.1 Template files](#251-template-files)
-  - [2.6 Using the calendar](#26-using-the-calendar)
-  - [2.7 Using the telescope pickers](#27-using-the-telescope-pickers)
-- [3. Bind it](#3-bind-it)
-- [4. The hardcoded stuff](#4-the-hardcoded-stuff)
+* [0. Install and setup](#0-install-and-setup)
+    * [0.0 Prerequisites](#00-prerequisites)
+        * [0.0.1 Telescope](#001-telescope)
+        * [0.0.2 calendar-vim Plugin (optional)](#002-calendar-vim-plugin-optional)
+        * [0.0.3 For pasting images: xclip (optional)](#003-for-pasting-images-xclip-optional)
+        * [0.0.4 For image previews: telescope-media-files.nvim (optional)](#004-for-image-previews-telescope-media-filesnvim-optional)
+            * [catimg](#catimg)
+            * [viu](#viu)
+            * [telescope-media-files.nvim](#telescope-media-filesnvim)
+    * [0.1 Install the plugin](#01-install-the-plugin)
+        * [0.1.0 Other useful plugins](#010-other-useful-plugins)
+    * [0.2 Configure telekasten.nvim](#02-configure-telekastennvim)
+    * [0.3 Configure your own colors](#03-configure-your-own-colors)
+* [1. Get Help](#1-get-help)
+* [2. Use it](#2-use-it)
+    * [2.0 Telekasten command](#20-telekasten-command)
+    * [2.1 Telekasten command palette](#21-telekasten-command-palette)
+    * [2.2 Telekasten lua functions](#22-telekasten-lua-functions)
+    * [2.3 Link notation](#23-link-notation)
+    * [2.4 Tag notation](#24-tag-notation)
+    * [2.5 Note templates](#25-note-templates)
+        * [2.5.1 Template files](#251-template-files)
+    * [2.6 Using the calendar](#26-using-the-calendar)
+    * [2.7 Using the telescope pickers](#27-using-the-telescope-pickers)
+* [3. Bind it](#3-bind-it)
+* [4. The hardcoded stuff](#4-the-hardcoded-stuff)
 
 <!-- vim-markdown-toc -->
 
@@ -823,6 +823,7 @@ Currently, the following substitutions will be made during new note creation:
 | specifier in template | expands to | example |
 | --- | --- | --- |
 | `{{title}}` | the title of the note | My new note |
+| `{{shorttitle}}` | the short title of the note | dir/subdir/My Note -> My Note |
 | `{{uuid}}` | UUID for the note | 202201271129 |
 | `{{date}}` | date in iso format | 2021-11-21 |
 | `{{prevday}}` | previous day's date in iso format | 2021-11-20 |

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -847,27 +847,28 @@ The following substitutions will be made during new note creation:
 | specifier       |                       |                             |
 | in template     | expands to            | example                     |
 +-----------------+-----------------------+-----------------------------+
-| `{{title}}`       | the title of the note | My new note                 |
-| `{{uuid}}`        | UUID of the note      | 202201271129                |
-| `{{date}}`        | date in iso format    | 2021-11-21                  |
-| `{{prevday}}`     | previous day, iso     | 2021-11-20                  |
-| `{{nextday}}`     | next day, iso         | 2021-11-22                  |
-| `{{hdate}}`       | date in long format   | Sunday, November 21st, 2021 |
-| `{{rfc3339}}`     | date in RFC3339 format| 2021-11-21T14:30Z+01:00     |
-| `{{week}}`        | week of the year      | 46                          |
-| `{{prevweek}}`    | previous week         | 45                          |
-| `{{nextweek}}`    | next week             | 47                          |
-| `{{isoweek}}`     | week in iso format    | 2021-46                     |
-| `{{isoprevweek}}` | last week, iso        | 2021-45                     |
-| `{{isonextweek}}` | next week, iso        | 2021-47                     |
-| `{{year}}`        | year                  | 2021                        |
-| `{{monday}}`      | Monday, iso           | 2021-11-15                  |
-| `{{tuesday}}`     | Tuesday, iso          | 2021-11-16                  |
-| `{{wednesday}}`   | Wednesday, iso        | 2021-11-17                  |
-| `{{thursday}}`    | Thursday, iso         | 2021-11-18                  |
-| `{{friday}}`      | Friday, iso           | 2021-11-19                  |
-| `{{saturday}}`    | Saturday, iso         | 2021-11-20                  |
-| `{{sunday}}`      | Sunday, iso (see note)| 2021-11-21                  |
+| `{{title}}`       | the title of the note       | My new note                 |
+| `{{shorttitle}}   | the short title of the note | dir/dir/My Note -> My Note  |
+| `{{uuid}}`        | UUID of the note            | 202201271129                |
+| `{{date}}`        | date in iso format          | 2021-11-21                  |
+| `{{prevday}}`     | previous day, iso           | 2021-11-20                  |
+| `{{nextday}}`     | next day, iso               | 2021-11-22                  |
+| `{{hdate}}`       | date in long format         | Sunday, November 21st, 2021 |
+| `{{rfc3339}}`     | date in RFC3339 format      | 2021-11-21T14:30Z+01:00     |
+| `{{week}}`        | week of the year            | 46                          |
+| `{{prevweek}}`    | previous week               | 45                          |
+| `{{nextweek}}`    | next week                   | 47                          |
+| `{{isoweek}}`     | week in iso format          | 2021-46                     |
+| `{{isoprevweek}}` | last week, iso              | 2021-45                     |
+| `{{isonextweek}}` | next week, iso              | 2021-47                     |
+| `{{year}}`        | year                        | 2021                        |
+| `{{monday}}`      | Monday, iso                 | 2021-11-15                  |
+| `{{tuesday}}`     | Tuesday, iso                | 2021-11-16                  |
+| `{{wednesday}}`   | Wednesday, iso              | 2021-11-17                  |
+| `{{thursday}}`    | Thursday, iso               | 2021-11-18                  |
+| `{{friday}}`      | Friday, iso                 | 2021-11-19                  |
+| `{{saturday}}`    | Saturday, iso               | 2021-11-20                  |
+| `{{sunday}}`      |  Sunday, iso (see note)| 2021-11-21                         |
 +-----------------+-----------------------+-----------------------------+
 Note: Sunday is adjusted to match the user's `calendar_monday` preference.
 

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -613,6 +613,11 @@ local function linesubst(line, title, dates, uuid)
         uuid = ""
     end
 
+    shorttitle = string.match(title, '^.+/(.+)$')
+    if shorttitle == nil then
+        shorttitle = title
+    end
+
     local substs = {
         hdate = dates.hdate,
         week = dates.week,
@@ -637,6 +642,7 @@ local function linesubst(line, title, dates, uuid)
         saturday = dates.saturday,
 
         title = title,
+        shorttitle = shorttitle,
         uuid = uuid,
     }
     for k, v in pairs(substs) do

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -613,7 +613,7 @@ local function linesubst(line, title, dates, uuid)
         uuid = ""
     end
 
-    shorttitle = string.match(title, '^.+/(.+)$')
+    local shorttitle = string.match(title, "^.+/(.+)$")
     if shorttitle == nil then
         shorttitle = title
     end


### PR DESCRIPTION
## Proposed change

This PR implements a `shorttitle` option for template substitutions. When used, a note created in a sub directory such as `school/class/My New Note` becomes `My New Note`.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
