### PR TITLE
Added Toggling Todos in Visual Range

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,10 @@ The plugin defines the following functions:
     - this function accepts a parameter `{i}`. If `true`, it will enter input mode by pressing the 'A' key. This is
       useful when being used in a simple `inoremap` key mapping like shown in [Bind it](#3-bind-it).
     - example: `toggle_todo({ i=true })`
+    - this function can also be used in `visual` mode  to toggle the status of multiple lines.
+    - if using a keymapping to `toggle_todo` in visual mode, make sure to use `:Telekasten toggle_todo<CR>`
+      instead of `<cmd>Telekasten toggle_todo<CR>` to avoid neovim sending the wrong visual selection to
+      telekasten.
 - `show_backlinks()` : opens a telescope search for notes that `[[link]]` back to the current note.
 - `find_friends()` : opens a telescope search for notes that also `[[link]]` to the link under the cursor.
 - `insert_img_link()` : opens a telescope search for all media (PDFs, images, videos (MP4, webm)) and places a markdown

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -649,6 +649,11 @@ telekasten.toggle_todo({opts})~
   Turns a line into a `- [ ] ` todo line, or toggle between `- [ ]`, `- [x]`,
   and `-` .
 
+  This can also be used in visual mode to toggle the status of multiple lines.
+  If using a keymapping to `toggle_todo` in visual mode, make sure the `rhs` is
+  `:Telekasten` `toggle_todo<CR>` instead of `<cmd>Telekasten` `toggle_todo<CR>`
+  to avoid neovim sending the wrong visual selection.
+
   Valid keys for {opts}
 
   i:~

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1532,8 +1532,7 @@ local function PreviewImg(opts)
             preview_type = "media",
 
             attach_mappings = function(prompt_bufnr, map)
-                actions.select_default:replace(function()
-                    actions.close(prompt_bufnr)
+                actions.select_default:replace(function() actions.close(prompt_bufnr)
                 end)
                 map("i", "<c-y>", picker_actions.yank_img_link(opts))
                 map("i", "<c-i>", picker_actions.paste_img_link(opts))
@@ -2718,28 +2717,39 @@ local function ToggleTodo(opts)
     -- - [x] by -
     -- enter insert mode if opts.i == true
     opts = opts or {}
-    local linenr = vim.api.nvim_win_get_cursor(0)[1]
-    local curline = vim.api.nvim_buf_get_lines(0, linenr - 1, linenr, false)[1]
-    local stripped = vim.trim(curline)
-    local repline
-    if
-        vim.startswith(stripped, "- ") and not vim.startswith(stripped, "- [")
-    then
-        repline = curline:gsub("%- ", "- [ ] ", 1)
-    else
-        if vim.startswith(stripped, "- [ ]") then
-            repline = curline:gsub("%- %[ %]", "- [x]", 1)
+    -- Neovim sends wrong visual selection when using a mapping
+    -- See https://github.com/neovim/neovim/issues/15144
+    vim.cmd("execute 'normal! \\<ESC>'")
+    local startline = vim.api.nvim_buf_get_mark(0, "<")[1]
+    local endline = vim.api.nvim_buf_get_mark(0, ">")[1]
+    local cursorlinenr = vim.api.nvim_win_get_cursor(0)[1]
+    if startline == 0 or endline == 0 then
+        startline = cursorlinenr
+        endline = cursorlinenr
+    end
+    for curlinenr = startline, endline do
+        local curline = vim.api.nvim_buf_get_lines(0, curlinenr - 1, curlinenr, false)[1]
+        local stripped = vim.trim(curline)
+        local repline
+        if
+            vim.startswith(stripped, "- ") and not vim.startswith(stripped, "- [")
+        then
+            repline = curline:gsub("%- ", "- [ ] ", 1)
         else
-            if vim.startswith(stripped, "- [x]") then
-                repline = curline:gsub("%- %[x%]", "-", 1)
+            if vim.startswith(stripped, "- [ ]") then
+                repline = curline:gsub("%- %[ %]", "- [x]", 1)
             else
-                repline = curline:gsub("(%S)", "- [ ] %1", 1)
+                if vim.startswith(stripped, "- [x]") then
+                    repline = curline:gsub("%- %[x%]", "-", 1)
+                else
+                    repline = curline:gsub("(%S)", "- [ ] %1", 1)
+                end
             end
         end
-    end
-    vim.api.nvim_buf_set_lines(0, linenr - 1, linenr, false, { repline })
-    if opts.i then
-        vim.api.nvim_feedkeys("A", "m", false)
+        vim.api.nvim_buf_set_lines(0, curlinenr - 1, curlinenr, false, { repline })
+        if opts.i then
+            vim.api.nvim_feedkeys("A", "m", false)
+        end
     end
 end
 

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2717,13 +2717,14 @@ local function ToggleTodo(opts)
     -- - [x] by -
     -- enter insert mode if opts.i == true
     opts = opts or {}
-    -- Neovim sends wrong visual selection when using a mapping
-    -- See https://github.com/neovim/neovim/issues/15144
-    vim.cmd("execute 'normal! \\<ESC>'")
     local startline = vim.api.nvim_buf_get_mark(0, "<")[1]
     local endline = vim.api.nvim_buf_get_mark(0, ">")[1]
     local cursorlinenr = vim.api.nvim_win_get_cursor(0)[1]
-    if startline == 0 or endline == 0 then
+    -- to avoid the visual range marks not being reset when calling
+    -- command from normal mode
+    vim.api.nvim_buf_set_mark(0, "<", 0, 0, {})
+    vim.api.nvim_buf_set_mark(0, ">", 0, 0, {})
+    if startline <= 0 or endline <= 0 then
         startline = cursorlinenr
         endline = cursorlinenr
     end

--- a/plugin/telekasten.vim
+++ b/plugin/telekasten.vim
@@ -8,7 +8,7 @@ function! s:telekasten_complete(arg,line,pos)
   return join(l:candidates, "\n")
 endfunction
 
-command! -nargs=? -complete=custom,s:telekasten_complete Telekasten lua require('telekasten').panel(<f-args>)
+command! -nargs=? -range -complete=custom,s:telekasten_complete Telekasten lua require('telekasten').panel(<f-args>)
 
 " overriding does not work -- so this is done by the plugin now in post_open()
 " au BufNewFile,BufRead *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md  setf telekasten


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

Edit x2: Fixed the original issue.

This PR lets users toggle todos from a visual range. Selecting a visual range then executing `:Telekasten toggle_todo` will
change every line of the range to a `todo` and correctly toggle existing `todo` lines with the next state. 

It passes the `-range` flag to the main `Telekasten` command in `telekasten.vim`. I do not know if this is the best way to pass
a range to the `toggle_todo` subcommand but this looked like the only way for Neovim to do it. The only consequences I see from
doing it like this is *possible* changing the behavior of other subcommands but as far as I could tell from testing, if you select
a visual range for a different command, the only line that is used is the last where the cursor ends up.

Please let me know if you need additional info on why the code is written the way it is or if you see a better way to send the ranges.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
