### PR TITLE
Add an Agenda of TODOs that can be quickly edited and viewed.

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2980,7 +2980,7 @@ end
 -- OpenAgenda:
 -- ----------
 --
--- See all todo's in your agenda file.
+-- Opens the agenda.md file where your todos are stored.
 -- Creates the agenda.md if necessary.
 --
 local function OpenAgenda()
@@ -2999,7 +2999,14 @@ local function OpenAgenda()
     vim.cmd("e " .. fname)
 end
 
-local function ShowTodos()
+--
+-- ShowAgenda:
+-- ----------
+--
+-- See all todo's in your agenda file.
+-- Creates the agenda.md if necessary.
+--
+local function ShowAgenda()
     local fname = M.Cfg.home .. "/agenda" .. M.Cfg.extension
     local fexists = file_exists(fname)
     if not fexists then
@@ -3041,7 +3048,7 @@ M.show_tags = FindAllTags
 M.switch_vault = ChangeVault
 M.chdir = chdir
 M.open_agenda = OpenAgenda
-M.show_todos = ShowTodos
+M.show_agenda = ShowAgenda
 
 -- Telekasten command, completion
 local TelekastenCmd = {
@@ -3071,7 +3078,7 @@ local TelekastenCmd = {
             },
             { "toggle todo", "toggle_todo", M.toggle_todo },
             { "open agenda", "open_agenda", M.open_agenda },
-            { "show todos", "show_todos", M.show_todos },
+            { "show agenda", "show_agenda", M.show_agenda },
             { "show backlinks", "show_backlinks", M.show_backlinks },
             { "find friend notes", "find_friends", M.find_friends },
             {

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2975,6 +2975,44 @@ local function chdir(cfg)
     -- M.Cfg = vim.tbl_deep_extend("force", defaultConfig(new_home), cfg)
 end
 
+
+--
+-- OpenAgenda:
+-- ----------
+--
+-- See all todo's in your agenda file.
+-- Creates the agenda.md if necessary.
+--
+local function OpenAgenda()
+    opts = opts or {}
+
+    if not global_dir_check() then
+        return
+    end
+
+    local fname = M.Cfg.home .. "/agenda" .. M.Cfg.extension
+    local fexists = file_exists(fname)
+    if not fexists then
+        create_note_from_template("agenda", _, fname)
+    end
+
+    vim.cmd("e " .. fname)
+end
+
+local function ShowTodos()
+    local fname = M.Cfg.home .. "/agenda" .. M.Cfg.extension
+    local fexists = file_exists(fname)
+    if not fexists then
+        create_note_from_template("agenda", _, fname)
+    end
+
+    for line in io.lines(fname) do
+        if string.match(line, "- %[[ x]%]") then
+            print(line)
+        end
+    end
+end
+
 M.find_notes = FindNotes
 M.find_daily_notes = FindDailyNotes
 M.search_notes = SearchNotes
@@ -3002,6 +3040,8 @@ M.taglinks = taglinks
 M.show_tags = FindAllTags
 M.switch_vault = ChangeVault
 M.chdir = chdir
+M.open_agenda = OpenAgenda
+M.show_todos = ShowTodos
 
 -- Telekasten command, completion
 local TelekastenCmd = {
@@ -3030,6 +3070,8 @@ local TelekastenCmd = {
                 M.paste_img_and_link,
             },
             { "toggle todo", "toggle_todo", M.toggle_todo },
+            { "open agenda", "open_agenda", M.open_agenda },
+            { "show todos", "show_todos", M.show_todos },
             { "show backlinks", "show_backlinks", M.show_backlinks },
             { "find friend notes", "find_friends", M.find_friends },
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

***NOT READY TO MERGE***

This PR will add an `agenda` to `telekasten.nvim` that is a list of TODOs that a user can view and edit. Currently all this PR does is let you call `open_agenda` which will open an `agenda.<ext>` file in your `home` directory for telekasten and create it if necessary. The `show_agenda` command prints out every TODO item in the `agenda` file to neovim's normal text output. 

I know that `telekasten.nvim` is about notetaking but personally I see my agenda of TODOs as part of my notes since normally I need to use it to look at things like due dates and other things like that. Perfectly fine if this is not something that should be implemented since I know there are other plugins that do this but I think it would be more natural if it was builtin.

I want to add more to this PR so that you can use a `telescope` picker to view all of your TODOs that would open a buffer and show you any information you listed with the TODO.

So if your agenda was like this:

```markdown
# TODOs

- [ ] Do a thing
  - General information about this TODO
  - [ ] Subtask for "Do a thing" 
- [ ] Do another thing
  - Some more general information
```

Then picking the TODO `Do a thing` from a picker would show you

```markdown
- [ ] Do a thing
  - General information about this TODO
  - [ ] Subtask for "Do a thing" 
```

And allow you to edit the status or info of that TODO from the window.

Another feature that could be worked on is added a deadline to each TODO like in orgmode where there would be some fancy format to make sure you know when you need to complete each item. It would be nice if this could also be shown on the calendar as well.

Let me know if there's any info you want from me on my thought process for this or if this is just not something that could/should be a part of this plugin.

Thanks.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Not all of the requirements have been checked since this is not what I would consider a production ready PR. I wanted to get the idea out there to get some feedback.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally. (Feature not fully implemented)
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
