### PR TITLE
Add with live grep option to insert link function and find notes function

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,8 @@ The plugin defines the following functions:
   - **note**:
     - this function accepts a parameter `{i}`. If `true`, it will enter input mode by pressing the 'A' key. This is
       useful when being used in a simple `inoremap` key mapping like shown in [Bind it](#3-bind-it).
-    - example: `insert_link({ i=true })`
+      - example: `insert_link({ i=true })`
+    - this function accepts a parameter `{with_live_grep}`. If `true`, it will use live_grep picker and you can search file by file contents.
 - `follow_link()`: take text between brackets (linked note) or of a tag and open a Telescope file finder with it: selects note to
   open (incl. preview) - with optional note creation for non-existing notes, honoring the configured template
   - **note**:

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -537,8 +537,15 @@ telekasten.new_templated_note()~
   See also:~
       - |telekasten.template_files|
                                                     *telekasten.find_notes()*
-telekasten.find_notes()~
+telekasten.find_notes({opts})~
   Opens a Telescope file finder and lets you pick a note by title (file name).
+
+  Valid keys for {opts}
+
+  with_live_grep:~
+    If `true`, it will use live_grep picker and you can search file by file contents.
+
+    Default: `nil`
 
                                               *telekasten.find_daily_notes()*
 telekasten.find_daily_notes()~
@@ -630,6 +637,11 @@ telekasten.insert_link({opts})~
     If `true`, it will enter input mode by pressing the <A> key. This is useful
     when being used in a simple `inoremap` key mapping like shown in
     |telekasten.mappings|.
+
+    Default: `nil`
+
+  with_live_grep:~
+    If `true`, it will use live_grep picker and you can search file by file contents.
 
     Default: `nil`
 

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1858,22 +1858,38 @@ local function FindNotes(opts)
         return
     end
 
-    find_files_sorted({
-        prompt_title = "Find notes by name",
-        cwd = M.Cfg.home,
-        find_command = M.Cfg.find_command,
-        attach_mappings = function(_, map)
-            actions.select_default:replace(picker_actions.select_default)
-            map("i", "<c-y>", picker_actions.yank_link(opts))
-            map("i", "<c-i>", picker_actions.paste_link(opts))
-            map("n", "<c-y>", picker_actions.yank_link(opts))
-            map("n", "<c-i>", picker_actions.paste_link(opts))
-            map("i", "<c-cr>", picker_actions.paste_link(opts))
-            map("n", "<c-cr>", picker_actions.paste_link(opts))
-            return true
-        end,
-        sort = M.Cfg.sort,
-    })
+    local cwd = M.Cfg.home
+    local find_command = M.Cfg.find_command
+    local sort = M.Cfg.sort
+    local attach_mappings = function(_, map)
+	actions.select_default:replace(picker_actions.select_default)
+	map("i", "<c-y>", picker_actions.yank_link(opts))
+	map("i", "<c-i>", picker_actions.paste_link(opts))
+	map("n", "<c-y>", picker_actions.yank_link(opts))
+	map("n", "<c-i>", picker_actions.paste_link(opts))
+	map("i", "<c-cr>", picker_actions.paste_link(opts))
+	map("n", "<c-cr>", picker_actions.paste_link(opts))
+	return true
+    end
+
+    if opts.with_live_grep then
+        builtin.live_grep({
+            prompt_title = "Find notes by live grep",
+            cwd = cwd,
+            find_command = find_command,
+            attach_mappings = attach_mappings,
+            sort = sort,
+        })
+    else
+        find_files_sorted({
+            prompt_title = "Find notes by name",
+            cwd = cwd,
+            find_command = find_command,
+            attach_mappings = attach_mappings,
+            sort = sort,
+        })
+    end
+    
 end
 
 --

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1443,6 +1443,8 @@ local function InsertLink(opts)
     end
 
     local cwd = M.Cfg.home
+    local find_command = M.Cfg.find_command
+    local sort = M.Cfg.sort
     local attach_mappings = function(prompt_bufnr, map)
         actions.select_default:replace(function()
             actions.close(prompt_bufnr)
@@ -1470,16 +1472,16 @@ local function InsertLink(opts)
             prompt_title = "Insert link to note with live grep",
             cwd = cwd,
             attach_mappings = attach_mappings,
-            find_command = M.Cfg.find_command,
-            sort = M.Cfg.sort,
+            find_command = find_command,
+            sort = sort,
         })
     else
         find_files_sorted({
             prompt_title = "Insert link to note",
             cwd = cwd,
             attach_mappings = attach_mappings,
-            find_command = M.Cfg.find_command,
-            sort = M.Cfg.sort,
+            find_command = find_command,
+            sort = sort,
         })
     end
 end

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1442,38 +1442,72 @@ local function InsertLink(opts)
         return
     end
 
-    find_files_sorted({
-        prompt_title = "Insert link to note",
-        cwd = M.Cfg.home,
-        attach_mappings = function(prompt_bufnr, map)
-            actions.select_default:replace(function()
-                actions.close(prompt_bufnr)
-                local selection = action_state.get_selected_entry()
-                local pinfo = Pinfo:new({
-                    filepath = selection.value,
-                    opts,
-                })
-                vim.api.nvim_put(
-                    { "[[" .. pinfo.title .. "]]" },
-                    "",
-                    true,
-                    true
-                )
-                if opts.i then
-                    vim.api.nvim_feedkeys("A", "m", false)
-                end
-            end)
-            map("i", "<c-y>", picker_actions.yank_link(opts))
-            map("i", "<c-i>", picker_actions.paste_link(opts))
-            map("n", "<c-y>", picker_actions.yank_link(opts))
-            map("n", "<c-i>", picker_actions.paste_link(opts))
-            map("i", "<c-cr>", picker_actions.paste_link(opts))
-            map("n", "<c-cr>", picker_actions.paste_link(opts))
-            return true
-        end,
-        find_command = M.Cfg.find_command,
-        sort = M.Cfg.sort,
-    })
+    if opts.with_live_grep then
+        builtin.live_grep({
+            prompt_title = "Insert link to note with live grep",
+            cwd = M.Cfg.home,
+            find_command = M.Cfg.find_command,
+            attach_mappings = function(prompt_bufnr, map)
+                actions.select_default:replace(function()
+                    actions.close(prompt_bufnr)
+                    local selection = action_state.get_selected_entry()
+                    local pinfo = Pinfo:new({
+                        filepath = selection.filename,
+                        opts,
+                    })
+                    vim.api.nvim_put(
+                        { "[[" .. pinfo.title .. "]]" },
+                        "",
+                        true,
+                        true
+                    )
+                    if opts.i then
+                        vim.api.nvim_feedkeys("A", "m", false)
+                    end
+                end)
+                map("i", "<c-y>", picker_actions.yank_link(opts))
+                map("i", "<c-i>", picker_actions.paste_link(opts))
+                map("n", "<c-y>", picker_actions.yank_link(opts))
+                map("n", "<c-i>", picker_actions.paste_link(opts))
+                map("i", "<c-cr>", picker_actions.paste_link(opts))
+                map("n", "<c-cr>", picker_actions.paste_link(opts))
+                return true
+            end,
+        })
+    else
+        find_files_sorted({
+            prompt_title = "Insert link to note",
+            cwd = M.Cfg.home,
+            attach_mappings = function(prompt_bufnr, map)
+                actions.select_default:replace(function()
+                    actions.close(prompt_bufnr)
+                    local selection = action_state.get_selected_entry()
+                    local pinfo = Pinfo:new({
+                        filepath = selection.value,
+                        opts,
+                    })
+                    vim.api.nvim_put(
+                        { "[[" .. pinfo.title .. "]]" },
+                        "",
+                        true,
+                        true
+                    )
+                    if opts.i then
+                        vim.api.nvim_feedkeys("A", "m", false)
+                    end
+                end)
+                map("i", "<c-y>", picker_actions.yank_link(opts))
+                map("i", "<c-i>", picker_actions.paste_link(opts))
+                map("n", "<c-y>", picker_actions.yank_link(opts))
+                map("n", "<c-i>", picker_actions.paste_link(opts))
+                map("i", "<c-cr>", picker_actions.paste_link(opts))
+                map("n", "<c-cr>", picker_actions.paste_link(opts))
+                return true
+            end,
+            find_command = M.Cfg.find_command,
+            sort = M.Cfg.sort,
+        })
+    end
 end
 
 -- local function check_for_link_or_tag()

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1443,31 +1443,26 @@ local function InsertLink(opts)
     end
 
     local cwd = M.Cfg.home
-    local attach_mappings =  function(prompt_bufnr, map)
-	actions.select_default:replace(function()
-	    actions.close(prompt_bufnr)
-	    local selection = action_state.get_selected_entry()
-	    local pinfo = Pinfo:new({
-		filepath = selection.filename,
-		opts,
-	    })
-	    vim.api.nvim_put(
-		{ "[[" .. pinfo.title .. "]]" },
-		"",
-		true,
-		true
-	    )
-	    if opts.i then
-		vim.api.nvim_feedkeys("A", "m", false)
-	    end
-	end)
-	map("i", "<c-y>", picker_actions.yank_link(opts))
-	map("i", "<c-i>", picker_actions.paste_link(opts))
-	map("n", "<c-y>", picker_actions.yank_link(opts))
-	map("n", "<c-i>", picker_actions.paste_link(opts))
-	map("i", "<c-cr>", picker_actions.paste_link(opts))
-	map("n", "<c-cr>", picker_actions.paste_link(opts))
-	return true
+    local attach_mappings = function(prompt_bufnr, map)
+        actions.select_default:replace(function()
+            actions.close(prompt_bufnr)
+            local selection = action_state.get_selected_entry()
+            local pinfo = Pinfo:new({
+                filepath = selection.filename,
+                opts,
+            })
+            vim.api.nvim_put({ "[[" .. pinfo.title .. "]]" }, "", true, true)
+            if opts.i then
+                vim.api.nvim_feedkeys("A", "m", false)
+            end
+        end)
+        map("i", "<c-y>", picker_actions.yank_link(opts))
+        map("i", "<c-i>", picker_actions.paste_link(opts))
+        map("n", "<c-y>", picker_actions.yank_link(opts))
+        map("n", "<c-i>", picker_actions.paste_link(opts))
+        map("i", "<c-cr>", picker_actions.paste_link(opts))
+        map("n", "<c-cr>", picker_actions.paste_link(opts))
+        return true
     end
 
     if opts.with_live_grep then
@@ -1862,14 +1857,14 @@ local function FindNotes(opts)
     local find_command = M.Cfg.find_command
     local sort = M.Cfg.sort
     local attach_mappings = function(_, map)
-	actions.select_default:replace(picker_actions.select_default)
-	map("i", "<c-y>", picker_actions.yank_link(opts))
-	map("i", "<c-i>", picker_actions.paste_link(opts))
-	map("n", "<c-y>", picker_actions.yank_link(opts))
-	map("n", "<c-i>", picker_actions.paste_link(opts))
-	map("i", "<c-cr>", picker_actions.paste_link(opts))
-	map("n", "<c-cr>", picker_actions.paste_link(opts))
-	return true
+        actions.select_default:replace(picker_actions.select_default)
+        map("i", "<c-y>", picker_actions.yank_link(opts))
+        map("i", "<c-i>", picker_actions.paste_link(opts))
+        map("n", "<c-y>", picker_actions.yank_link(opts))
+        map("n", "<c-i>", picker_actions.paste_link(opts))
+        map("i", "<c-cr>", picker_actions.paste_link(opts))
+        map("n", "<c-cr>", picker_actions.paste_link(opts))
+        return true
     end
 
     if opts.with_live_grep then
@@ -1889,7 +1884,6 @@ local function FindNotes(opts)
             sort = sort,
         })
     end
-    
 end
 
 --

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1442,68 +1442,47 @@ local function InsertLink(opts)
         return
     end
 
+    local cwd = M.Cfg.home
+    local attach_mappings =  function(prompt_bufnr, map)
+	actions.select_default:replace(function()
+	    actions.close(prompt_bufnr)
+	    local selection = action_state.get_selected_entry()
+	    local pinfo = Pinfo:new({
+		filepath = selection.filename,
+		opts,
+	    })
+	    vim.api.nvim_put(
+		{ "[[" .. pinfo.title .. "]]" },
+		"",
+		true,
+		true
+	    )
+	    if opts.i then
+		vim.api.nvim_feedkeys("A", "m", false)
+	    end
+	end)
+	map("i", "<c-y>", picker_actions.yank_link(opts))
+	map("i", "<c-i>", picker_actions.paste_link(opts))
+	map("n", "<c-y>", picker_actions.yank_link(opts))
+	map("n", "<c-i>", picker_actions.paste_link(opts))
+	map("i", "<c-cr>", picker_actions.paste_link(opts))
+	map("n", "<c-cr>", picker_actions.paste_link(opts))
+	return true
+    end
+
     if opts.with_live_grep then
         builtin.live_grep({
             prompt_title = "Insert link to note with live grep",
-            cwd = M.Cfg.home,
+            cwd = cwd,
+            attach_mappings = attach_mappings,
             find_command = M.Cfg.find_command,
-            attach_mappings = function(prompt_bufnr, map)
-                actions.select_default:replace(function()
-                    actions.close(prompt_bufnr)
-                    local selection = action_state.get_selected_entry()
-                    local pinfo = Pinfo:new({
-                        filepath = selection.filename,
-                        opts,
-                    })
-                    vim.api.nvim_put(
-                        { "[[" .. pinfo.title .. "]]" },
-                        "",
-                        true,
-                        true
-                    )
-                    if opts.i then
-                        vim.api.nvim_feedkeys("A", "m", false)
-                    end
-                end)
-                map("i", "<c-y>", picker_actions.yank_link(opts))
-                map("i", "<c-i>", picker_actions.paste_link(opts))
-                map("n", "<c-y>", picker_actions.yank_link(opts))
-                map("n", "<c-i>", picker_actions.paste_link(opts))
-                map("i", "<c-cr>", picker_actions.paste_link(opts))
-                map("n", "<c-cr>", picker_actions.paste_link(opts))
-                return true
-            end,
+            sort = M.Cfg.sort,
         })
     else
         find_files_sorted({
             prompt_title = "Insert link to note",
-            cwd = M.Cfg.home,
-            attach_mappings = function(prompt_bufnr, map)
-                actions.select_default:replace(function()
-                    actions.close(prompt_bufnr)
-                    local selection = action_state.get_selected_entry()
-                    local pinfo = Pinfo:new({
-                        filepath = selection.value,
-                        opts,
-                    })
-                    vim.api.nvim_put(
-                        { "[[" .. pinfo.title .. "]]" },
-                        "",
-                        true,
-                        true
-                    )
-                    if opts.i then
-                        vim.api.nvim_feedkeys("A", "m", false)
-                    end
-                end)
-                map("i", "<c-y>", picker_actions.yank_link(opts))
-                map("i", "<c-i>", picker_actions.paste_link(opts))
-                map("n", "<c-y>", picker_actions.yank_link(opts))
-                map("n", "<c-i>", picker_actions.paste_link(opts))
-                map("i", "<c-cr>", picker_actions.paste_link(opts))
-                map("n", "<c-cr>", picker_actions.paste_link(opts))
-                return true
-            end,
+            cwd = cwd,
+            attach_mappings = attach_mappings,
             find_command = M.Cfg.find_command,
             sort = M.Cfg.sort,
         })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

Quote from #188 
> I use telekasten.nvim with new_note_filename = uuid.
People who use telekasten.nvim with filename uuid like me must watch file contents one by one when using the current InsertLink function.
I guess Anyone sometimes wants to search a linking file with live grep.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #188 
- This PR is related to issue: #188 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
