### PR TITLE
Add custom function option for UUID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,12 @@ require('telekasten').setup({
     -- "uuid-title" - Prefix title by uuid
     -- "title-uuid" - Suffix title with uuid
     new_note_filename = "title",
-    -- file uuid type ("rand" or input for os.date()")
+
+    --[[ file UUID type
+        - "rand"
+        - string input for os.date()
+        - or custom lua function that returns a string
+    --]]
     uuid_type = "%Y%m%d%H%M",
     -- UUID separator
     uuid_sep = "-",

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -243,8 +243,9 @@ telekasten.setup({opts})
 
                                            *telekasten.settings.uuid_type*
     uuid_type: ~
-        Type of UUID. Could be 'rand' for a random 6 character string, or a
-        time format to input in os.date() such as %Y%m%d%H%M.
+        Type of UUID. Could be 'rand' for a random 6 character string, a
+        time format to input in os.date() such as '%Y%m%d%H%M', or any lua
+        function like os.time() that returns a string.
 
         Default: '%Y%m%d%H%M'
 

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -64,7 +64,12 @@ local function defaultConfig(home)
         -- "uuid-title" - Prefix title by uuid
         -- "title-uuid" - Suffix title with uuid
         new_note_filename = "title",
-        -- file uuid type ("rand" or input for os.date()")
+
+        --[[ file UUID type
+           - "rand"
+           - string input for os.date()
+           - or custom lua function that returns a string
+        --]]
         uuid_type = "%Y%m%d%H%M",
         -- UUID separator
         uuid_sep = "-",
@@ -208,10 +213,12 @@ local function get_uuid(opts)
     opts.uuid_type = opts.uuid_type or M.Cfg.uuid_type
 
     local uuid
-    if opts.uuid_type ~= "rand" then
-        uuid = os.date(opts.uuid_type)
-    else
+    if opts.uuid_type == "rand" then
         uuid = random_variable(6)
+    elseif type(opts.uuid_type) == "function" then
+        uuid = opts.uuid_type()
+    else
+        uuid = os.date(opts.uuid_type)
     end
     return uuid
 end


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

This PR adds the ability to provide a lua function that generates the UUID for a new note. This allows users to configure telekasten with something like e.g.
```lua
require("telekasten").setup({
    uuid_type = os.time()
})
```
to create a filename with a unix time based UUID. While this `"unix"` timestamp option could be hardcoded as a `uuid_type`, passing any custom function allows users to define arbitrarily complex UUID patterns.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
