### PR TITLE
Add new precise time (hour:min:sec) templating options

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,8 @@ Currently, the following substitutions will be made during new note creation:
 | `{{shorttitle}}` | the short title of the note | dir/subdir/My Note -> My Note |
 | `{{uuid}}` | UUID for the note | 202201271129 |
 | `{{date}}` | date in iso format | 2021-11-21 |
+| `{{time24}}` | time with 24 hour clock | 19:12:23 |
+| `{{time12}}` | time with 12 hour clock | 07:12:23 PM |
 | `{{prevday}}` | previous day's date in iso format | 2021-11-20 |
 | `{{nextday}}` | next day's date in iso format | 2021-11-22 |
 | `{{hdate}}` | date in long format | Sunday, November 21st, 2021 |

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -900,6 +900,8 @@ The following substitutions will be made during new note creation:
 | `{{shorttitle}}   | the short title of the note | dir/dir/My Note -> My Note  |
 | `{{uuid}}`        | UUID of the note            | 202201271129                |
 | `{{date}}`        | date in iso format          | 2021-11-21                  |
+| `{{time24}}`      | time with 24 hour clock     | 19:12:23                    |
+| `{{time12}}`      | time with 12 hour clock     | 07:12:23 PM                 |
 | `{{prevday}}`     | previous day, iso           | 2021-11-20                  |
 | `{{nextday}}`     | next day, iso               | 2021-11-22                  |
 | `{{hdate}}`       | date in long format         | Sunday, November 21st, 2021 |

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -552,6 +552,8 @@ local dateformats = {
     date = "%Y-%m-%d",
     week = "%V",
     isoweek = "%Y-W%V",
+    time24 = "%H:%M:%S",
+    time12 = "%I:%M:%S %p",
 }
 
 local function calculate_dates(date)
@@ -591,6 +593,8 @@ local function calculate_dates(date)
         .. ":"
         .. zonemin
 
+    dates.time24 = os.date(df.time24, time)
+    dates.time12 = os.date(df.time12, time)
     dates.date = os.date(df.date, time)
     dates.prevday = os.date(df.date, time - oneday)
     dates.nextday = os.date(df.date, time + oneday)
@@ -644,33 +648,12 @@ local function linesubst(line, title, dates, uuid)
         shorttitle = title
     end
 
-    local substs = {
-        hdate = dates.hdate,
-        week = dates.week,
-        date = dates.date,
-        isoweek = dates.isoweek,
-        year = dates.year,
-        rfc3339 = dates.rfc3339,
+    local substs = vim.tbl_extend("error", dates, {
+        shorttitle,
+        uuid,
+        title,
+    })
 
-        prevday = dates.prevday,
-        nextday = dates.nextday,
-        prevweek = dates.prevweek,
-        nextweek = dates.nextweek,
-        isoprevweek = dates.isoprevweek,
-        isonextweek = dates.isonextweek,
-
-        sunday = dates.sunday,
-        monday = dates.monday,
-        tuesday = dates.tuesday,
-        wednesday = dates.wednesday,
-        thursday = dates.thursday,
-        friday = dates.friday,
-        saturday = dates.saturday,
-
-        title = title,
-        shorttitle = shorttitle,
-        uuid = uuid,
-    }
     for k, v in pairs(substs) do
         line = line:gsub("{{" .. k .. "}}", v)
     end


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adds two new template options, `{{time24}}` and `{{time12}}`, which allow users to inject the more precise time into their notes / journal entries. Personally, I like having additional context of the specific hour and minute for journal entries.

I tossed around the idea of implementing this feature as separate `{{hour}}`, `{{min}}`, `{{sec}}`, etc templates so users could build their own specific time representation, but at that point we're just re-implementing `os.date()` in our templating engine :laughing:. 

Another option is we could allow custom lua functions to be defined in the users configuration, run those functions when `create_note_from_template` is called, and merge the results into the existing `substs` table.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
