### PR TITLE
Fixed issue where notes created from templates would error if _ was previously set.

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1334,7 +1334,12 @@ local function FindDailyNotes(opts)
             or M.Cfg.dailies_create_nonexisting == true
         )
     then
-        create_note_from_template(today, _, fname, M.note_type_templates.daily)
+        create_note_from_template(
+            today,
+            nil,
+            fname,
+            M.note_type_templates.daily
+        )
         opts.erase = true
         opts.erase_file = fname
     end
@@ -1384,7 +1389,12 @@ local function FindWeeklyNotes(opts)
             or M.Cfg.weeklies_create_nonexisting == true
         )
     then
-        create_note_from_template(title, _, fname, M.note_type_templates.weekly)
+        create_note_from_template(
+            title,
+            nil,
+            fname,
+            M.note_type_templates.weekly
+        )
         opts.erase = true
         opts.erase_file = fname
     end
@@ -1760,7 +1770,7 @@ local function GotoDate(opts)
     then
         create_note_from_template(
             word,
-            _,
+            nil,
             fname,
             M.note_type_templates.daily,
             opts.dates
@@ -2612,7 +2622,12 @@ local function GotoThisWeek(opts)
             or M.Cfg.weeklies_create_nonexisting == true
         )
     then
-        create_note_from_template(title, _, fname, M.note_type_templates.weekly)
+        create_note_from_template(
+            title,
+            nil,
+            fname,
+            M.note_type_templates.weekly
+        )
         opts.erase = true
         opts.erase_file = fname
     end


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

#231 describes an issue where creating a note from a template seem to fail for some users.

The failure occurs in `linesubst` when attempting to substitute the uuid. Instead of the expected string or nil value, it receives a boolean value which cannot be substituted in.

The reason for this boolean uuid stems from how the calls are made:  
`FindDailyNotes`, `FindWeeklyNotes`, `GotoDate` and `GotoThisWeek` all make a call to `create_note_from_template` similar to this:

```lua
create_note_from_template(title, _, fname, M.note_type_templates.weekly)
```

Where `_` is meant to represent a nil uuid.  
This in turn calls `linesubst` with the uuid provided. The issue is that `_` appears to have a boolean assigned to it. It's not clear whether this is a problem with this plugin, or elsewhere, but simply using `nil` instead will ensure the intended value is always passed.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #231 
- This PR is related to issue: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
