### PR TITLE
fix show_tags for some users

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2672,7 +2672,7 @@ local function FindAllTags(opts)
                         action_state.get_selected_entry().value.tag
                     local follow_opts = {
                         follow_tag = selection,
-                        show_link_counts = true,
+                        show_link_counts = false,
                         templateDir = templateDir,
                     }
                     actions._close(prompt_bufnr, false)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

set  `show_link_counts = false` in `FindAllTags` second prompt
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

Some users experience an empty dialog after calling show_tags, when the tag has been selected and a prompt with the files that contain the tag should appear.

My understanding is that the flag will call linkutils.generate_backlink_map to get a list of backlinks. I can't see the purpose for the count in the context of showing tags, so I believe that false should be the value for all cases

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #226
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
