### PR TITLE
Make aliased wikilink highlighting consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ hi tkLink ctermfg=Blue cterm=bold,underline guifg=blue gui=bold,underline
 hi tkBrackets ctermfg=gray guifg=gray
 ```
 
+**NOTE**: Users configuring the following highlight groups prior to 09/2023, be aware they are deprecated:
+- `tkHighlightedAliasLink`: this syntax group is now covered by `tkHighlight`
+- `tkLinkBody`: this syntax group is renamed to `tkAliasedLink`
+- `tkAliasedLink`: this group used to cover the whole link, it is now equivalent to the former `tkLinkBody` 
+- `tkLinkAlias`: this rule is deprecated
+
 ### Mappings
 
 The real power of Telekasten lays in defining sensible mappings to make your

--- a/README.md
+++ b/README.md
@@ -285,12 +285,6 @@ hi tkLink ctermfg=Blue cterm=bold,underline guifg=blue gui=bold,underline
 hi tkBrackets ctermfg=gray guifg=gray
 ```
 
-**NOTE**: Users configuring the following highlight groups prior to 09/2023, be aware they are deprecated:
-- `tkHighlightedAliasLink`: this syntax group is now covered by `tkHighlight`
-- `tkLinkBody`: this syntax group is renamed to `tkAliasedLink`
-- `tkAliasedLink`: this group used to cover the whole link, it is now equivalent to the former `tkLinkBody` 
-- `tkLinkAlias`: this rule is deprecated
-
 ### Mappings
 
 The real power of Telekasten lays in defining sensible mappings to make your

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Telekasten.nvim allows you to color your `[[links]]` and `#tags` by providing
 the following syntax groups:
 
 - `tkLink` : the link title inside the brackets
+- `tkAliasedLink` : the concealed portion of `[[concealed link|link alias]]`
 - `tkBrackets` : the brackets surrounding the link title
 - `tkHighlight` : ==highlighted== text (non-standard markdown)
 - `tkTag` :  well, tags

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -527,6 +527,12 @@ You can assign colors to the new syntax groups in your `init.vim`:
   hi tkTag ctermfg=175 guifg=#d3869B
 <
 
+NOTE: Users configuring the following highlight groups prior to 09/2023, be aware they are deprecated:
+- `tkHighlightedAliasLink`: this syntax group is now covered by `tkHighlight`
+- `tkLinkBody`: this syntax group is renamed to `tkAliasedLink`
+- `tkAliasedLink`: this group used to cover the whole link, it is now equivalent to the former `tkLinkBody`
+- `tkLinkAlias`: this rule is deprecated
+
 ================================================================================
 Section 3: Usage                                              *telekasten.usage*
 

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -496,10 +496,7 @@ groups:
 - `tkBrackets` : the brackets surrounding the link title
 - `tkHighlight` : ==highlighted== text (non-standard markdown)
 - `tkTag` :  well, tags
-- `tkAliasedLink` : link with alias
-- `tkHighlightedAliasedLink` : link with alias in `tkAliasedLink`
-- `tkLinkAlias` : body of the link (left part of `[[aaa|bbb]]`)
-- `tkLinkBody` : alias of the link (right part of `[[aaa|bbb]]`)
+- `tkAliasedLink` : the concealed part of the link (left part of `[[aaa|bbb]]`)
 
 `tkHighlight`, has nothing to do with links but I added it anyway, since I like
 highlighting text when taking notes.

--- a/syntax/telekasten.vim
+++ b/syntax/telekasten.vim
@@ -8,7 +8,9 @@ unlet b:current_syntax
 
 syn region Comment matchgroup=Comment start="<!--" end="-->"  contains=tkTag keepend
 
-syntax region tkLink matchgroup=tkBrackets start=/\[\[/ end=/\]\]/ display oneline 
+syntax region tkLink matchgroup=tkBrackets start=/\[\[/ end=/\]\]/ keepend display oneline contains=tkAliasedLink
+syntax match tkAliasedLink "[^\[\]]\+|" contained conceal
+
 syntax region tkHighlight matchgroup=tkBrackets start=/==/ end=/==/ display oneline contains=tkHighlightedAliasedLink
 
 syntax match tkTag "\v#[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*"
@@ -17,10 +19,6 @@ syntax match tkTag "\v:[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*:"
 syntax match tkTagSep "\v\s*,\s*" contained
 syntax region tkTag matchgroup=tkBrackets start=/^tags\s*:\s*\[\s*/ end=/\s*\]\s*$/ contains=tkTagSep display oneline
 
-syntax region tkAliasedLink start="\[\[[^\]]\+|" end="\]\]" keepend oneline contains=tkLinkAlias,tkLinkBody
-syntax region tkHighlightedAliasedLink start="\[\[[^\]]\+|" end="\]\]" keepend oneline contained contains=tkLinkAlias,tkLinkBody
-syntax region tkLinkAlias start="|"ms=s+1 end=".+\]\]"me=e-2 keepend contained
-syntax region tkLinkBody start="\[\["ms=s+2 end="|" keepend contained conceal
 
 let b:current_syntax = 'telekasten'
 

--- a/syntax/telekasten.vim
+++ b/syntax/telekasten.vim
@@ -11,7 +11,7 @@ syn region Comment matchgroup=Comment start="<!--" end="-->"  contains=tkTag kee
 syntax region tkLink matchgroup=tkBrackets start=/\[\[/ end=/\]\]/ keepend display oneline contains=tkAliasedLink
 syntax match tkAliasedLink "[^\[\]]\+|" contained conceal
 
-syntax region tkHighlight matchgroup=tkBrackets start=/==/ end=/==/ display oneline contains=tkHighlightedAliasedLink
+syntax region tkHighlight matchgroup=tkBrackets start=/==/ end=/==/ display oneline contains=tkAliasedLink
 
 syntax match tkTag "\v#[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*"
 syntax match tkTag "\v:[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*:"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

This makes the highlighting of aliased wikilinks consistent with other wikilink highlighting.

Additionally, it condenses the syntax rules to streamline highlighting setup:
- removes `tkHighlightedAliasedLink` (this is now simply covered by `tkHighlight`)
- removes `tkLinkAlias` (which wasn't working correctly)
- renaming `tkLinkBody` to `tkAliasedLink` (`tkAliasedLink` was the rule that made highlighting inconsistent, and its rule is now covered by `tkLink`)

This change may break compatibility for users with `tkHighlightedAliasedLink`, `tkLinkAlias`, and `tkAliasedLink` highlight rules defined.

Given the Highlighting rules below:
```lua
cmd("hi tkBrackets ctermfg=gray guifg=gray")
cmd("hi tkLink ctermfg=72 guifg=#689d6a cterm=bold,underline gui=bold,underline")

cmd("hi tkLinkBody     guifg=blue")  -- the wikilink path that will be concealed
cmd("hi tkLinkAlias    guifg=red")  -- the alias for the wikilink
cmd("hi tkAliasedLink  guifg=yellow")  -- the complete aliased wikilink
-- cmd("hi tkHighlightedAliasedLink guifg=orange")  -- above, highlighted

cmd("hi tkHighlight guifg=#ab66ea gui=bold")
```

Before:
<img width="402" alt="Screenshot 2023-07-23 at 17 04 17" src="https://github.com/renerocksai/telekasten.nvim/assets/8768815/9a642b6f-d6b7-4d5d-bda0-b8348ec35859">

After:
<img width="401" alt="Screenshot 2023-07-23 at 17 55 32" src="https://github.com/renerocksai/telekasten.nvim/assets/8768815/1d58625a-6a37-469d-b095-f34ccfcf367d">

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #275 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
