### PR TITLE
Enable config for creation of new note with Ctrl-n

### DIFF
--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -449,6 +449,14 @@ telekasten.setup({opts})
 
         Default: `nil`
         Example: `"call jobstart('firefox --new-window {{url}}')"`
+
+                                  *telekasten.settings.enable_create_new*
+    enable_create_new: ~
+        Flag that determines if creating new notes with <C-n> in enabled when
+        using the `find_notes` picker.
+
+        Default: true
+
                                                *telekasten.calendar_opts*
     -----------------------------------
     Valid keys for {opts.calendar_opts}

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -150,6 +150,8 @@ local function defaultConfig(home)
         media_previewer = "telescope-media-files",
         -- A customizable fallback handler for urls.
         follow_url_fallback = nil,
+        -- Enable creation new notes with Ctrl-n when finding notes
+        enable_create_new = true,
     }
     M.Cfg = cfg
     M.note_type_templates = {
@@ -1737,8 +1739,10 @@ local function FindNotes(opts)
             map("n", "<c-i>", picker_actions.paste_link(opts))
             map("i", "<c-cr>", picker_actions.paste_link(opts))
             map("n", "<c-cr>", picker_actions.paste_link(opts))
-            map("i", "<c-n>", picker_actions.create_new(opts))
-            map("n", "<c-n>", picker_actions.create_new(opts))
+            if M.Cfg.enable_create_new then
+                map("i", "<c-n>", picker_actions.create_new(opts))
+                map("n", "<c-n>", picker_actions.create_new(opts))
+            end
             return true
         end
 


### PR DESCRIPTION
## Proposed change

A previous addition added the functionality to create a new note with `<C-n>` when using the `find_note` picker (see https://github.com/renerocksai/telekasten.nvim/issues/141 and https://github.com/renerocksai/telekasten.nvim/pull/230). While this is a nice addition, it interferes with the default key mappings of Telescope for moving up and down the list of results, which uses `<C-n>` and `<C-p>`. It would be nice to have a configuration setting to be able to disable this picker mapping, so that it does not interfere with the Telescope default.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

I have not coded much Lua other than setting my own Neovim configuration, so I'm note sure if this proposed change is in line with how the plugin is generally written. It is a very simple addition: a new config setting and an if clause that checks the value of this setting. It works fine locally for me, but I might be doing some non-standard thing that I (not being a plugin developer myself) don't know I shouldn't do.

Given that, I hope that the idea behind the PR can be considered even if the contributed code itself is not up-to-snuff. I'd of course be happy to update the PR with any desired changes to make it fit into the plugin better.

I have not added any changes to the documentation on purpose since I don't know if the proposed addition is good enough to be merged as-is, but I'm happy to add the relevant documentation (to this PR or another) once the addition is deemed acceptable.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [X] I am running the **latest** version of the plugin.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [X] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [X] The `doc/telekasten.txt` helpfile has been updated according to this change.