### PR TITLE
Allow link syntax highlights to cross lines

### DIFF
--- a/syntax/telekasten.vim
+++ b/syntax/telekasten.vim
@@ -8,10 +8,10 @@ unlet b:current_syntax
 
 syn region Comment matchgroup=Comment start="<!--" end="-->"  contains=tkTag keepend
 
-syntax region tkLink matchgroup=tkBrackets start=/\[\[/ end=/\]\]/ keepend display oneline contains=tkAliasedLink
+syntax region tkLink matchgroup=tkBrackets start=/\[\[/ end=/\]\]/ keepend display contains=tkAliasedLink
 syntax match tkAliasedLink "[^\[\]]\+|" contained conceal
 
-syntax region tkHighlight matchgroup=tkBrackets start=/==/ end=/==/ display oneline contains=tkAliasedLink
+syntax region tkHighlight matchgroup=tkBrackets start=/==/ end=/==/ display contains=tkAliasedLink
 
 syntax match tkTag "\v#[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*"
 syntax match tkTag "\v:[a-zA-ZÀ-ÿ]+[a-zA-ZÀ-ÿ0-9/\-_]*:"


### PR DESCRIPTION
## Proposed change

This change makes link syntax highlighting able to cross lines, see #303 for details.

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #303 

## Checklist

- [X] I am running the **latest** version of the plugin.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [X] The code has been checked with luacheck (a `.luacheckrc` file is provided)