### PR TITLE
Allow following line-split links on the first line

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2122,6 +2122,7 @@ local function FollowLink(opts)
                 vim.cmd("normal yi]")
                 title = vim.fn.getreg('"0')
                 title = title:gsub("^(%[)(.+)(%])$", "%2")
+                title = title:gsub("%s*\n", " ")
                 title = linkutils.remove_alias(title)
             else
                 -- we are in an external [link]


### PR DESCRIPTION
## Proposed change

This PR allows following line-split links if the cursor is on the first line of the split; see https://github.com/renerocksai/telekasten.nvim/issues/303#issuecomment-1959460689. I thought that it'd be good to have this very simple change, even if there is no easy way to get the same functionality on the second line of the split (which remains to be seen, I guess).

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #303

## Checklist

- [X] I am running the **latest** version of the plugin.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [X] The code has been checked with luacheck (a `.luacheckrc` file is provided)