### PR TITLE
config setting for inbox folder

### DIFF
--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -449,6 +449,13 @@ telekasten.setup({opts})
 
         Default: `smart`
 
+                                   *telekasten.settings.smart_inbox_folder*
+    smart_inbox_folder:~
+        Path to an zettlekasten-style "inbox" folder. If new_note_location is
+        set to 'smart' all non-daily and non-weekly notes will be created
+        in this folder.
+
+        Default: `nil`
                                    *telekasten.settings.rename_update_links*
     rename_update_links:~
         If `true`, telekasten will automatically update the links after a file

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -674,6 +674,8 @@ function Pinfo:resolve_link(title, opts)
     opts.weeklies = opts.weeklies or M.Cfg.weeklies
     opts.dailies = opts.dailies or M.Cfg.dailies
     opts.home = opts.home or M.Cfg.home
+    opts.smart_inbox_folder = opts.smart_inbox_folder
+        or M.Cfg.smart_inbox_folder
     opts.extension = opts.extension or M.Cfg.extension
     opts.template_handling = opts.template_handling or M.Cfg.template_handling
     opts.new_note_location = opts.new_note_location or M.Cfg.new_note_location
@@ -743,7 +745,8 @@ function Pinfo:resolve_link(title, opts)
         _, _, self.calendar_info = check_if_daily_or_weekly(self.title) -- will set today as default, so leave in!
 
         if opts.new_note_location == "smart" then
-            self.filepath = opts.home .. "/" .. self.filename -- default
+            self.root_dir = opts.smart_inbox_folder or opts.home
+            self.filepath = self.root_dir .. "/" .. self.filename -- default
             self.is_daily, self.is_weekly, self.calendar_info =
                 check_if_daily_or_weekly(self.title)
             if self.is_daily == true then


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

Ahrens "Taking Smart Notes" describes the need for an 'inbox' for fleeting notes.
This diff adds a config setting to put all new notes into an inbox folder.

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
