### PR TITLE
feat(293): Tab autocompletes with folders in notes home directory

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1982,9 +1982,16 @@ local function CreateNoteSelectTemplate(opts)
             return
         end
 
+        -- get the current working directory
+        local current_dir = vim.fn.getcwd()
+        -- change the cwd to the configured home directory, so tab completion 
+        -- works for the folders in that directory
+        vim.fn.chdir(M.Cfg.home)
         fileutils.prompt_title(M.Cfg.extension, nil, function(title)
             on_create_with_template(opts, title)
         end)
+        -- change back to the original directory
+        vim.fn.chdir(current_dir)
     end)
 end
 
@@ -2065,9 +2072,16 @@ local function CreateNote(opts)
             return CreateNoteSelectTemplate(opts)
         end
 
+        -- get the current working directory
+        local current_dir = vim.fn.getcwd()
+        -- change the cwd to the configured home directory, so tab completion 
+        -- works for the folders in that directory
+        vim.fn.chdir(M.Cfg.home)
         fileutils.prompt_title(M.Cfg.extension, nil, function(title)
             on_create(opts, title)
         end)
+        -- change back to the original directory
+        vim.fn.chdir(current_dir)
     end)
 end
 

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1984,7 +1984,7 @@ local function CreateNoteSelectTemplate(opts)
 
         -- get the current working directory
         local current_dir = vim.fn.getcwd()
-        -- change the cwd to the configured home directory, so tab completion 
+        -- change the cwd to the configured home directory, so tab completion
         -- works for the folders in that directory
         vim.fn.chdir(M.Cfg.home)
         fileutils.prompt_title(M.Cfg.extension, nil, function(title)
@@ -2074,7 +2074,7 @@ local function CreateNote(opts)
 
         -- get the current working directory
         local current_dir = vim.fn.getcwd()
-        -- change the cwd to the configured home directory, so tab completion 
+        -- change the cwd to the configured home directory, so tab completion
         -- works for the folders in that directory
         vim.fn.chdir(M.Cfg.home)
         fileutils.prompt_title(M.Cfg.extension, nil, function(title)


### PR DESCRIPTION
changing the current working directory when creating a new note to the configured home directory


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->
This addresses the feature/bug outlined in #293 
By changing the CWD before and after the new note prompt is shown, the desired behavior is achieved.
I don't think that this should negatively affect any users.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #293 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
