### PR TITLE
chore: more helpful img paste error msg

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -480,7 +480,11 @@ local function imgFromClipboard()
             vim.fn.system("rm " .. png)
             vim.api.nvim_err_writeln(
                 string.format(
-                    "Unable to write image %s.\nIs there an image on the clipboard?\nSee also issue 131",
+                    "Unable to write image %s.\n"
+                        .. "Is there an image on the clipboard?\n"
+                        .. "Have you set clipboard_program to your preferred paste command? "
+                        .. "(see :help telekasten.configuration)\n"
+                        .. "See also issue 131",
                     png
                 )
             )


### PR DESCRIPTION



<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Point users towards `clipboard_program` when pasting images fails as telekasten will prefer xsel/xclip on wayland if those are installed, even if wl-paste is available as well. This may discourage naive work-arounds such as uninstalling xsel/xclip, which may be undesirable if users frequently switch between x11/wayland.

## Type of change

When running wayland and having xclip and xsel installed, but *not* having set `clipboard_program`, telekasten will prefer and try to use xclip/xsel, which will fail.

A work-around may be uninstalling xclip and xsel, but we can point users towards being able to configure the preferred tool via clipboard_program so that they may keep xclip/xsel installed.

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [x] More helpful error message

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Example of user installing/uninstalling tools instead of setting `clipboard_program`: https://github.com/nvim-telekasten/telekasten.nvim/issues/340

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
