### PR TITLE
feat: implement robust picker abstraction for telescope, fzf-lua, and snacks.nvim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: test test-taglinks test-telescope test-fzf test-snacks test-all test-watch help
+
+help:
+	@echo "Available targets:"
+	@echo "  test          - Run all tests (taglinks pattern)"
+	@echo "  test-taglinks - Run taglinks tests only"
+	@echo "  test-telescope - Run telescope picker tests only"
+	@echo "  test-fzf      - Run fzf picker tests only"
+	@echo "  test-snacks   - Run snacks picker tests only"
+	@echo "  test-all      - Run all tests with color output"
+	@echo "  test-watch    - Run tests in watch mode (requires entr)"
+
+test: test-all
+
+test-taglinks:
+	@nvim --headless -u NONE -c "set rtp+=." -c "lua require('telekasten.utils.taglinks')._testme()" -c "quit"
+
+test-telescope:
+	@nvim --headless -u NONE -c "set rtp+=." -c "lua require('telekasten.picker.telescope_test')._testme()" -c "quit"
+
+test-fzf:
+	@nvim --headless -u NONE -c "set rtp+=." -c "lua require('telekasten.picker.fzf_test')._testme()" -c "quit"
+
+test-snacks:
+	@nvim --headless -u NONE -c "set rtp+=." -c "lua require('telekasten.picker.snacks_test')._testme()" -c "quit"
+
+test-all:
+	@nvim --headless -u NONE -c "set rtp+=." -c "luafile test_all.lua"
+
+test-watch:
+	@echo "Watching for changes... (Ctrl+C to stop)"
+	@find lua -name "*.lua" | entr -c make test

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -28,6 +28,7 @@ CONTENTS
     1. Setup ......................... |telekasten.setup|
         1.1 Requirements ..............|telekasten.requirements|
         1.2 Configuration .............|telekasten.configuration|
+        1.3 Picker Backends ...........|telekasten.picker_backends|
     2. Highlights .................... |telekasten.highlights|
     3. Usage ......................... |telekasten.usage|
         3.1 Link Notation ............ |telekasten.link_notation|
@@ -126,6 +127,9 @@ telekasten.setup({opts})
 
       -- Command palette theme: dropdown (window) or ivy (bottom panel)
       command_palette_theme = "ivy",
+
+      -- Picker backend: 'telescope', 'fzf', or 'snacks'
+      picker = "telescope",
 
       -- Tag list theme:
         -- get_cursor (small tag list at cursor)
@@ -469,6 +473,42 @@ telekasten.setup({opts})
 
         Default: `true`
 
+                                              *telekasten.settings.picker*
+    picker:~
+        Picker backend to use for file and note selection. Telekasten supports
+        three picker backends through a unified abstraction layer.
+
+        Valid options are:
+        - `'telescope'` .. use telescope.nvim (default, most features)
+        - `'fzf'` .. use fzf-lua (fast, lightweight)
+        - `'snacks'` .. use snacks.nvim (modern, good performance)
+
+        Default: 'telescope'
+
+        Example configurations:
+        >
+        -- Using telescope (default)
+        require('telekasten').setup({
+            home = '~/zettelkasten',
+            picker = 'telescope',  -- or omit this line
+        })
+
+        -- Using fzf-lua
+        require('telekasten').setup({
+            home = '~/zettelkasten',
+            picker = 'fzf',
+        })
+
+        -- Using snacks.nvim
+        require('telekasten').setup({
+            home = '~/zettelkasten',
+            picker = 'snacks',
+        })
+<
+
+        See also:~
+            - |telekasten.picker_backends|
+
                                        *telekasten.settings.media_previewer*
     media_previewer:~
         Previewer used for viewing media / image files. There are three
@@ -538,6 +578,152 @@ telekasten.setup({opts})
         Default: 'left-fit'
 
 --------------------------------------------------------------------------------
+Section 1.3: Picker Backends                        *telekasten.picker_backends*
+
+Telekasten supports three picker backends through a unified abstraction layer.
+All core functionality (finding notes, following links, inserting links, etc.)
+works identically across all three backends.
+
+                                                   *telekasten.picker.telescope*
+Telescope (default):~
+    The default picker backend with the most features and widest support.
+
+    Requirements:
+    - nvim-telescope/telescope.nvim
+    - nvim-lua/plenary.nvim
+
+    Features:
+    - Full support for all telekasten functionality
+    - Media file preview (with telescope-media-files.nvim)
+    - Custom entry display formatting
+    - Devicons support
+    - Multiple themes (dropdown, ivy, cursor)
+
+    Installation example (using lazy.nvim):
+    >
+    {
+        'renerocksai/telekasten.nvim',
+        dependencies = {
+            'nvim-telescope/telescope.nvim',
+            'nvim-lua/plenary.nvim',
+        },
+        config = function()
+            require('telekasten').setup({
+                home = vim.fn.expand('~/zettelkasten'),
+                -- picker = 'telescope' is the default
+            })
+        end
+    }
+<
+
+                                                        *telekasten.picker.fzf*
+FZF-lua:~
+    A fast and lightweight alternative picker backend.
+
+    Requirements:
+    - ibhagwan/fzf-lua
+    - nvim-lua/plenary.nvim
+
+    Features:
+    - Fast fuzzy finding
+    - Multiple themes (dropdown, ivy, cursor)
+    - Live grep support
+    - Media preview (requires chafa)
+
+    Installation example (using lazy.nvim):
+    >
+    {
+        'renerocksai/telekasten.nvim',
+        dependencies = {
+            'ibhagwan/fzf-lua',
+            'nvim-lua/plenary.nvim',
+        },
+        config = function()
+            require('telekasten').setup({
+                home = vim.fn.expand('~/zettelkasten'),
+                picker = 'fzf',
+            })
+        end
+    }
+<
+
+                                                     *telekasten.picker.snacks*
+Snacks:~
+    A modern picker backend with good performance.
+
+    Requirements:
+    - folke/snacks.nvim
+    - nvim-lua/plenary.nvim
+
+    Features:
+    - Modern interface
+    - Good performance
+    - Multiple themes (dropdown, ivy, cursor)
+    - Live grep support
+
+    Installation example (using lazy.nvim):
+    >
+    {
+        'renerocksai/telekasten.nvim',
+        dependencies = {
+            'folke/snacks.nvim',
+            'nvim-lua/plenary.nvim',
+        },
+        config = function()
+            require('telekasten').setup({
+                home = vim.fn.expand('~/zettelkasten'),
+                picker = 'snacks',
+            })
+        end
+    }
+<
+
+                                                  *telekasten.picker.comparison*
+Feature Comparison:~
+
+    +---------------------+------------+----------+----------+
+    | Feature             | Telescope  | FZF-lua  | Snacks   |
+    +---------------------+------------+----------+----------+
+    | File finding        | ✓          | ✓        | ✓        |
+    | Live grep           | ✓          | ✓        | ✓        |
+    | Link insertion      | ✓          | ✓        | ✓        |
+    | Link following      | ✓          | ✓        | ✓        |
+    | Media preview       | ✓          | ✓*       | ✗        |
+    | Custom themes       | ✓          | ✓        | ✓        |
+    | Devicons            | ✓          | ✓        | ✗        |
+    | Link counts         | ✓          | ✓        | ✓        |
+    +---------------------+------------+----------+----------+
+    * Requires chafa for media preview in FZF-lua
+
+All three pickers provide the same core functionality for note management.
+Choose based on your preference, performance requirements, and existing setup.
+
+                                              *telekasten.picker.switching*
+Switching Pickers:~
+
+    You can switch between pickers at any time by changing the `picker`
+    setting in your configuration:
+    >
+    require('telekasten').setup({
+        home = '~/zettelkasten',
+        picker = 'snacks',  -- change to 'telescope' or 'fzf'
+    })
+<
+
+    Notes:
+    - Switching pickers requires the new picker plugin to be installed
+    - All your notes and configurations remain unchanged
+    - Keymappings and commands work identically across all pickers
+
+                                           *telekasten.picker.backward_compat*
+Backward Compatibility:~
+
+    The picker abstraction layer is fully backward compatible:
+    - Existing configurations continue to work unchanged
+    - Default remains telescope if no picker is specified
+    - No breaking changes to the API
+
+================================================================================
 Section 2: Highlights                                    *telekasten.highlights*
 
 Telekasten.nvim allows you to color your `[[links]]` by providing a few syntax
@@ -1152,7 +1338,7 @@ Still, to avoid the most common Windows issue:
 
 
 ================================================================================
-Section 5: Credits                                          *telekasten.credits*
+Section 6: Credits                                          *telekasten.credits*
 
 Credits go to:
 * {Conni2461} on GitHub for the awesome pull request and support!

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1,6 +1,7 @@
 local picker = require("telekasten.picker")
 local debug_utils = require("plenary.debug_utils")
 local filetype = require("plenary.filetype")
+local scan = require("plenary.scandir")
 local taglinks = require("telekasten.utils.taglinks")
 local tagutils = require("telekasten.utils.tags")
 local linkutils = require("telekasten.utils.links")

--- a/lua/telekasten/picker/fzf.lua
+++ b/lua/telekasten/picker/fzf.lua
@@ -1,0 +1,444 @@
+-- lua/telekasten/picker/fzf.lua
+-- FZF-Lua backend implementation for telekasten picker abstraction
+
+local M = {}
+
+-- Lazy-loaded fzf-lua module
+local fzf_loaded = false
+local fzf_lua
+
+-- Load fzf-lua
+local function ensure_fzf()
+    if fzf_loaded then
+        return true
+    end
+
+    local ok, fzf = pcall(require, "fzf-lua")
+    if not ok then
+        error(
+            "fzf-lua is not installed. Please install fzf-lua or use a different picker backend."
+        )
+    end
+
+    fzf_lua = fzf
+    fzf_loaded = true
+    return true
+end
+
+-- Backend configuration
+M.config = {
+    winopts = {
+        height = 0.85,
+        width = 0.80,
+        row = 0.35,
+        col = 0.50,
+        border = "rounded",
+    },
+    previewers = {
+        builtin = {
+            extensions = {
+                ["png"] = { "chafa" },
+                ["jpg"] = { "chafa" },
+                ["jpeg"] = { "chafa" },
+                ["gif"] = { "chafa" },
+                ["webp"] = { "chafa" },
+            },
+        },
+    },
+}
+
+function M.setup(opts)
+    ensure_fzf()
+    M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+end
+
+-- ============================================================================
+-- Helper Functions
+-- ============================================================================
+
+-- Convert attach_mappings to fzf-lua actions
+local function convert_mappings(attach_mappings)
+    if not attach_mappings then
+        return nil
+    end
+
+    local actions_obj = {}
+    local map_fn = function(mode, key, action_fn)
+        -- Store action for this key
+        actions_obj[key] = action_fn
+    end
+
+    -- Call the attach_mappings with our mock actions and map
+    attach_mappings(actions_obj, map_fn)
+
+    -- Convert to fzf-lua format
+    local fzf_actions = {}
+    for key, action_fn in pairs(actions_obj) do
+        fzf_actions[key] = function(selected, opts_inner)
+            -- Create a mock prompt_bufnr for compatibility
+            local mock_bufnr = vim.api.nvim_get_current_buf()
+
+            -- Store selected for get_selection
+            M._current_selection = selected and selected[1]
+
+            -- Call the action
+            action_fn(mock_bufnr)
+        end
+    end
+
+    return fzf_actions
+end
+
+-- Format entry for display
+local function format_entry(entry, opts)
+    if type(entry) == "string" then
+        return entry
+    end
+
+    if entry.display then
+        if type(entry.display) == "function" then
+            return entry.display(entry)
+        else
+            return entry.display
+        end
+    end
+
+    return entry.value or tostring(entry)
+end
+
+-- ============================================================================
+-- Core Picker Implementations
+-- ============================================================================
+
+function M.find_files(opts)
+    ensure_fzf()
+    opts = opts or {}
+
+    -- For simple cases, use fzf-lua's built-in files
+    if not opts.show_link_counts and not opts.search_pattern then
+        local fzf_opts = {
+            prompt = (opts.prompt_title or "Find Files") .. "> ",
+            cwd = opts.cwd,
+            query = opts.default_text,
+            winopts = M.config.winopts,
+            actions = convert_mappings(opts.attach_mappings),
+        }
+
+        return fzf_lua.files(fzf_opts)
+    end
+
+    -- For complex cases, scan and format manually
+    local scan = require("plenary.scandir")
+
+    local scan_opts = {
+        search_pattern = opts.search_pattern,
+        depth = opts.search_depth,
+    }
+
+    local file_list = scan.scan_dir(opts.cwd, scan_opts)
+
+    -- Filter by extension
+    if opts.filter_extensions then
+        local filtered = {}
+        for _, file in ipairs(file_list) do
+            local ext = file:match("^.+(%..+)$")
+            for _, allowed_ext in ipairs(opts.filter_extensions) do
+                if ext == allowed_ext then
+                    table.insert(filtered, file)
+                    break
+                end
+            end
+        end
+        file_list = filtered
+    end
+
+    -- Sort files
+    if opts.sort == "modified" then
+        table.sort(file_list, function(a, b)
+            return vim.fn.getftime(a) > vim.fn.getftime(b)
+        end)
+    else
+        table.sort(file_list, function(a, b)
+            return a > b
+        end)
+    end
+
+    -- Format entries with link counts if needed
+    local formatted_entries = {}
+    for _, file in ipairs(file_list) do
+        local display = file:gsub(opts.cwd .. "/", "")
+
+        if opts.show_link_counts and opts.link_counts then
+            local nlinks = opts.link_counts.link_counts[file] or 0
+            local nbacks = opts.link_counts.backlink_counts[file] or 0
+            display = string.format("L%-3d B%-3d %s", nlinks, nbacks, display)
+        end
+
+        table.insert(formatted_entries, display)
+    end
+
+    local fzf_opts = {
+        prompt = (opts.prompt_title or "Find Files") .. "> ",
+        fzf_opts = {
+            ["--no-sort"] = "",
+        },
+        winopts = M.config.winopts,
+        actions = convert_mappings(opts.attach_mappings),
+    }
+
+    -- Handle preview
+    if opts.preview_type == "media" then
+        fzf_opts.previewer = "builtin"
+    end
+
+    return fzf_lua.fzf_exec(formatted_entries, fzf_opts)
+end
+
+function M.live_grep(opts)
+    ensure_fzf()
+    opts = opts or {}
+
+    local fzf_opts = {
+        prompt = (opts.prompt_title or "Live Grep") .. "> ",
+        cwd = opts.cwd,
+        search = opts.default_text or "",
+        winopts = M.config.winopts,
+        actions = convert_mappings(opts.attach_mappings),
+    }
+
+    -- Handle search_dirs
+    if opts.search_dirs and #opts.search_dirs > 0 then
+        fzf_opts.cwd = opts.search_dirs[1]
+    end
+
+    return fzf_lua.live_grep(fzf_opts)
+end
+
+function M.custom_picker(opts)
+    ensure_fzf()
+    opts = opts or {}
+
+    local results = opts.results or {}
+
+    -- Format entries using entry_maker if provided
+    local formatted_entries = {}
+    if opts.entry_maker then
+        for _, item in ipairs(results) do
+            local entry = opts.entry_maker(item)
+            table.insert(formatted_entries, format_entry(entry, opts))
+        end
+    else
+        for _, item in ipairs(results) do
+            table.insert(formatted_entries, tostring(item))
+        end
+    end
+
+    local fzf_opts = {
+        prompt = (opts.prompt_title or "Select") .. "> ",
+        winopts = vim.tbl_deep_extend("force", M.config.winopts, {}),
+        actions = convert_mappings(opts.attach_mappings),
+        fzf_opts = {
+            ["--no-sort"] = "",
+        },
+    }
+
+    -- Apply theme
+    if opts.theme == "dropdown" then
+        fzf_opts.winopts.height = 0.4
+        fzf_opts.winopts.width = 0.6
+        fzf_opts.winopts.row = 0.4
+    elseif opts.theme == "ivy" then
+        fzf_opts.winopts.height = 0.4
+        fzf_opts.winopts.row = 1.0
+        fzf_opts.winopts.border = "none"
+    elseif opts.theme == "cursor" then
+        fzf_opts.winopts.height = 0.3
+        fzf_opts.winopts.width = 0.3
+        fzf_opts.winopts.row = 0.5
+        fzf_opts.winopts.col = 0.5
+    end
+
+    return fzf_lua.fzf_exec(formatted_entries, fzf_opts)
+end
+
+-- ============================================================================
+-- Actions
+-- ============================================================================
+
+M.actions = {}
+
+-- Store current selection for get_selection
+M._current_selection = nil
+M._current_line = nil
+
+function M.actions.select_default(callback)
+    return function(selected, fzf_opts)
+        if callback then
+            -- Store selection
+            M._current_selection = selected and selected[1]
+
+            -- Create mock prompt_bufnr
+            local mock_bufnr = vim.api.nvim_get_current_buf()
+            callback(mock_bufnr)
+        else
+            -- Default behavior: open file
+            if selected and selected[1] then
+                vim.cmd("edit " .. selected[1])
+            end
+        end
+    end
+end
+
+function M.actions.close(opts)
+    opts = opts or {}
+    return function(selected, fzf_opts)
+        -- fzf-lua handles closing automatically
+
+        -- Erase file if specified
+        if opts.erase and opts.erase_file then
+            if vim.fn.filereadable(opts.erase_file) == 1 then
+                vim.fn.delete(opts.erase_file)
+            end
+        end
+    end
+end
+
+function M.actions.yank_selection(get_text_fn)
+    return function(selected, fzf_opts)
+        if not selected or not selected[1] then
+            return
+        end
+
+        M._current_selection = selected[1]
+
+        -- Create a mock entry
+        local mock_entry = {
+            value = selected[1],
+            filename = selected[1],
+        }
+
+        local text = get_text_fn(mock_entry)
+        vim.fn.setreg('"', text)
+        print("yanked " .. text)
+    end
+end
+
+function M.actions.paste_selection(get_text_fn, insert_after)
+    return function(selected, fzf_opts)
+        if not selected or not selected[1] then
+            return
+        end
+
+        M._current_selection = selected[1]
+
+        -- Create a mock entry
+        local mock_entry = {
+            value = selected[1],
+            filename = selected[1],
+        }
+
+        local text = get_text_fn(mock_entry)
+        vim.api.nvim_put({ text }, "", true, true)
+
+        if insert_after then
+            vim.api.nvim_feedkeys("A", "m", false)
+        end
+    end
+end
+
+function M.actions.get_selection()
+    -- Return mock entry with stored selection
+    if M._current_selection then
+        return {
+            value = M._current_selection,
+            filename = M._current_selection,
+        }
+    end
+    return nil
+end
+
+function M.actions.get_current_line()
+    return M._current_line or ""
+end
+
+-- ============================================================================
+-- Themes
+-- ============================================================================
+
+M.themes = {}
+
+function M.themes.dropdown(opts)
+    opts = opts or {}
+    return vim.tbl_deep_extend("force", {
+        winopts = {
+            height = 0.4,
+            width = 0.6,
+            row = 0.4,
+            col = 0.5,
+        },
+    }, opts)
+end
+
+function M.themes.ivy(opts)
+    opts = opts or {}
+    return vim.tbl_deep_extend("force", {
+        winopts = {
+            height = 0.4,
+            row = 1.0,
+            border = "none",
+        },
+    }, opts)
+end
+
+function M.themes.cursor(opts)
+    opts = opts or {}
+    return vim.tbl_deep_extend("force", {
+        winopts = {
+            height = 0.3,
+            width = 0.3,
+            row = 0.5,
+            col = 0.5,
+        },
+    }, opts)
+end
+
+-- ============================================================================
+-- Utilities
+-- ============================================================================
+
+function M.create_entry_display(spec)
+    -- FZF-lua doesn't have telescope's entry_display
+    -- Return a simple formatter function
+    return function(entry)
+        if type(entry) == "table" and entry.display then
+            if type(entry.display) == "function" then
+                return entry.display(entry)
+            else
+                return entry.display
+            end
+        end
+        return tostring(entry.value or entry)
+    end
+end
+
+function M.supports(feature)
+    local supported = {
+        "live_grep",
+        "themes",
+    }
+
+    for _, f in ipairs(supported) do
+        if f == feature then
+            return true
+        end
+    end
+
+    -- Partial support
+    if feature == "media_preview" then
+        return vim.fn.executable("chafa") == 1
+    end
+
+    return false
+end
+
+return M

--- a/lua/telekasten/picker/fzf_test.lua
+++ b/lua/telekasten/picker/fzf_test.lua
@@ -1,0 +1,234 @@
+-- lua/telekasten/picker/fzf_test.lua
+-- Test functions for fzf-lua picker (using taglinks testing pattern)
+
+local M = {}
+
+local function _print_debug(x, prefix)
+    prefix = prefix or ""
+    for k, v in pairs(x) do
+        print(prefix .. k .. ": " .. tostring(v))
+    end
+end
+
+local function _expect(x, y, context)
+    for k, v in pairs(y) do
+        if x[k] ~= v then
+            if context then
+                print("Test: " .. context)
+            end
+            print("expected:")
+            _print_debug(y, "  ")
+            print("got:")
+            _print_debug(x, "  ")
+            assert(false, "Test failed: " .. (context or "unknown"))
+        end
+    end
+end
+
+-- Test backend structure
+M._test_backend_structure = function()
+    local fzf = require("telekasten.picker.fzf")
+
+    -- Test required functions exist
+    assert(fzf.find_files ~= nil, "find_files missing")
+    assert(fzf.live_grep ~= nil, "live_grep missing")
+    assert(fzf.custom_picker ~= nil, "custom_picker missing")
+    assert(fzf.setup ~= nil, "setup missing")
+
+    -- Test actions exist
+    assert(fzf.actions ~= nil, "actions table missing")
+    assert(fzf.actions.select_default ~= nil, "select_default action missing")
+    assert(fzf.actions.close ~= nil, "close action missing")
+    assert(fzf.actions.yank_selection ~= nil, "yank_selection action missing")
+    assert(fzf.actions.paste_selection ~= nil, "paste_selection action missing")
+    assert(fzf.actions.get_selection ~= nil, "get_selection action missing")
+    assert(
+        fzf.actions.get_current_line ~= nil,
+        "get_current_line action missing"
+    )
+
+    -- Test themes exist
+    assert(fzf.themes ~= nil, "themes table missing")
+    assert(fzf.themes.dropdown ~= nil, "dropdown theme missing")
+    assert(fzf.themes.ivy ~= nil, "ivy theme missing")
+    assert(fzf.themes.cursor ~= nil, "cursor theme missing")
+
+    print("✓ Backend structure tests passed")
+end
+
+-- Test actions functionality
+M._test_actions = function()
+    local fzf = require("telekasten.picker.fzf")
+
+    -- Test get_selection with no selection
+    fzf._current_selection = nil
+    local result = fzf.actions.get_selection()
+    assert(result == nil, "get_selection should return nil when no selection")
+
+    -- Test get_selection with selection
+    fzf._current_selection = "/test/path.md"
+    result = fzf.actions.get_selection()
+    _expect(result, {
+        value = "/test/path.md",
+        filename = "/test/path.md",
+    }, "get_selection with file")
+
+    -- Test get_current_line
+    fzf._current_line = nil
+    result = fzf.actions.get_current_line()
+    assert(result == "", "get_current_line should return empty string when nil")
+
+    fzf._current_line = "test line"
+    result = fzf.actions.get_current_line()
+    assert(result == "test line", "get_current_line should return stored line")
+
+    -- Cleanup
+    fzf._current_selection = nil
+    fzf._current_line = nil
+
+    print("✓ Actions tests passed")
+end
+
+-- Test themes configuration
+M._test_themes = function()
+    local fzf = require("telekasten.picker.fzf")
+
+    -- Test dropdown theme
+    local dropdown = fzf.themes.dropdown()
+    assert(dropdown.winopts ~= nil, "dropdown should have winopts")
+    assert(dropdown.winopts.height == 0.4, "dropdown height should be 0.4")
+    assert(dropdown.winopts.width == 0.6, "dropdown width should be 0.6")
+
+    -- Test ivy theme
+    local ivy = fzf.themes.ivy()
+    assert(ivy.winopts ~= nil, "ivy should have winopts")
+    assert(ivy.winopts.height == 0.4, "ivy height should be 0.4")
+    assert(ivy.winopts.row == 1.0, "ivy should be at bottom")
+
+    -- Test cursor theme
+    local cursor = fzf.themes.cursor()
+    assert(cursor.winopts ~= nil, "cursor should have winopts")
+    assert(cursor.winopts.height == 0.3, "cursor height should be 0.3")
+    assert(cursor.winopts.width == 0.3, "cursor width should be 0.3")
+
+    -- Test theme merging
+    local custom_dropdown = fzf.themes.dropdown({
+        winopts = { width = 0.8 },
+    })
+    assert(
+        custom_dropdown.winopts.width == 0.8,
+        "theme should merge custom width"
+    )
+    assert(
+        custom_dropdown.winopts.height == 0.4,
+        "theme should keep default height"
+    )
+
+    print("✓ Theme tests passed")
+end
+
+-- Test utilities
+M._test_utilities = function()
+    local fzf = require("telekasten.picker.fzf")
+
+    -- Test supports
+    assert(fzf.supports("live_grep") == true, "should support live_grep")
+    assert(fzf.supports("themes") == true, "should support themes")
+    assert(
+        fzf.supports("nonexistent") == false,
+        "should not support unknown feature"
+    )
+
+    -- Test create_entry_display
+    local formatter = fzf.create_entry_display({})
+    assert(
+        type(formatter) == "function",
+        "create_entry_display should return function"
+    )
+
+    -- Test formatter with string
+    local result = formatter("test string")
+    assert(result == "test string", "formatter should handle strings")
+
+    -- Test formatter with table
+    result = formatter({ display = "display text", value = "value" })
+    assert(result == "display text", "formatter should use display field")
+
+    result = formatter({ value = "some value" })
+    assert(result == "some value", "formatter should fall back to value field")
+
+    print("✓ Utility tests passed")
+end
+
+-- Test backend validation
+M._test_validation = function()
+    local fzf = require("telekasten.picker.fzf")
+    local picker_init = require("telekasten.picker.init")
+
+    local valid, err = picker_init.validate_backend(fzf)
+    assert(valid == true, "fzf backend should pass validation: " .. (err or ""))
+
+    print("✓ Validation tests passed")
+end
+
+-- Test picker initialization
+M._test_picker_init = function()
+    local picker_init = require("telekasten.picker.init")
+
+    -- Test setup with fzf
+    picker_init.setup("fzf", {})
+    assert(picker_init.get_backend() == "fzf", "backend should be set to fzf")
+
+    -- Test that functions are forwarded
+    assert(picker_init.find_files ~= nil, "find_files should be forwarded")
+    assert(picker_init.live_grep ~= nil, "live_grep should be forwarded")
+    assert(
+        picker_init.custom_picker ~= nil,
+        "custom_picker should be forwarded"
+    )
+
+    print("✓ Picker initialization tests passed")
+end
+
+-- Main test runner
+M._testme = function()
+    print("\n=== Running FZF Picker Tests ===\n")
+
+    local tests = {
+        { name = "Backend Structure", fn = M._test_backend_structure },
+        { name = "Actions", fn = M._test_actions },
+        { name = "Themes", fn = M._test_themes },
+        { name = "Utilities", fn = M._test_utilities },
+        { name = "Validation", fn = M._test_validation },
+        { name = "Picker Initialization", fn = M._test_picker_init },
+    }
+
+    local passed = 0
+    local failed = 0
+
+    for _, test in ipairs(tests) do
+        local ok, err = pcall(test.fn)
+        if ok then
+            passed = passed + 1
+        else
+            failed = failed + 1
+            print("✗ " .. test.name .. " FAILED:")
+            print("  " .. tostring(err))
+        end
+    end
+
+    print("\n=== Test Summary ===")
+    print(string.format("Passed: %d", passed))
+    print(string.format("Failed: %d", failed))
+    print(string.format("Total:  %d", passed + failed))
+
+    if failed == 0 then
+        print("\n✓ All tests passed!")
+    else
+        print("\n✗ Some tests failed")
+    end
+
+    return failed == 0
+end
+
+return M

--- a/lua/telekasten/picker/init.lua
+++ b/lua/telekasten/picker/init.lua
@@ -1,0 +1,344 @@
+-- lua/telekasten/picker/init.lua
+-- Abstraction layer for multiple picker backends (telescope, fzf-lua, snacks)
+
+local M = {}
+
+-- Current backend configuration
+M.backend = nil
+M.impl = nil
+
+-- Available backends
+local BACKENDS = {
+    telescope = "telekasten.picker.telescope",
+    fzf = "telekasten.picker.fzf",
+    snacks = "telekasten.picker.snacks",
+}
+
+-- Setup the picker backend
+-- @param backend string: "telescope", "fzf", or "snacks"
+-- @param opts table: backend-specific configuration options
+function M.setup(backend, opts)
+    backend = backend or "telescope"
+    opts = opts or {}
+
+    if not BACKENDS[backend] then
+        error(
+            string.format(
+                "Unknown picker backend: %s. Available: telescope, fzf, snacks",
+                backend
+            )
+        )
+    end
+
+    local ok, impl = pcall(require, BACKENDS[backend])
+    if not ok then
+        error(
+            string.format(
+                "Failed to load picker backend '%s': %s",
+                backend,
+                impl
+            )
+        )
+    end
+
+    M.backend = backend
+    M.impl = impl
+
+    if M.impl.setup then
+        M.impl.setup(opts)
+    end
+
+    return M
+end
+
+-- Get the current backend name
+function M.get_backend()
+    return M.backend
+end
+
+-- Ensure backend is initialized
+local function ensure_backend()
+    if not M.impl then
+        M.setup("telescope") -- default fallback
+    end
+end
+
+-- ============================================================================
+-- Core Picker API - All backends must implement these
+-- ============================================================================
+
+-- Find files with sorting and filtering
+-- @param opts table: picker options
+--   - prompt_title: string
+--   - cwd: string
+--   - default_text: string
+--   - search_pattern: string (regex pattern)
+--   - search_depth: number
+--   - filter_extensions: table of strings
+--   - preview_type: "text" | "media"
+--   - sort: "filename" | "modified"
+--   - show_link_counts: boolean
+--   - attach_mappings: function(actions, map)
+function M.find_files(opts)
+    ensure_backend()
+    return M.impl.find_files(opts)
+end
+
+-- Live grep with custom patterns
+-- @param opts table: picker options
+--   - prompt_title: string
+--   - cwd: string
+--   - default_text: string
+--   - search_dirs: table of strings
+--   - attach_mappings: function(actions, map)
+function M.live_grep(opts)
+    ensure_backend()
+    return M.impl.live_grep(opts)
+end
+
+-- Custom picker with arbitrary results
+-- @param opts table: picker options
+--   - prompt_title: string
+--   - results: table (list of items)
+--   - entry_maker: function(entry) -> { value, display, ordinal }
+--   - attach_mappings: function(actions, map)
+--   - theme: "dropdown" | "ivy" | "cursor" | nil
+function M.custom_picker(opts)
+    ensure_backend()
+    return M.impl.custom_picker(opts)
+end
+
+-- ============================================================================
+-- Action Abstraction - Common actions across all pickers
+-- ============================================================================
+
+M.actions = {}
+
+-- Action builder functions that return backend-specific actions
+-- These should be called within attach_mappings
+
+function M.actions.select_default(callback)
+    ensure_backend()
+    return M.impl.actions.select_default(callback)
+end
+
+function M.actions.close(opts)
+    ensure_backend()
+    return M.impl.actions.close(opts)
+end
+
+function M.actions.yank_selection(get_text_fn)
+    ensure_backend()
+    return M.impl.actions.yank_selection(get_text_fn)
+end
+
+function M.actions.paste_selection(get_text_fn, insert_after)
+    ensure_backend()
+    return M.impl.actions.paste_selection(get_text_fn, insert_after)
+end
+
+-- Get the selected entry/line from picker state
+function M.actions.get_selection()
+    ensure_backend()
+    return M.impl.actions.get_selection()
+end
+
+-- Get current line text from prompt
+function M.actions.get_current_line()
+    ensure_backend()
+    return M.impl.actions.get_current_line()
+end
+
+-- ============================================================================
+-- Theme/Layout Abstraction
+-- ============================================================================
+
+M.themes = {}
+
+function M.themes.dropdown(opts)
+    ensure_backend()
+    if M.impl.themes and M.impl.themes.dropdown then
+        return M.impl.themes.dropdown(opts)
+    end
+    return opts or {}
+end
+
+function M.themes.ivy(opts)
+    ensure_backend()
+    if M.impl.themes and M.impl.themes.ivy then
+        return M.impl.themes.ivy(opts)
+    end
+    return opts or {}
+end
+
+function M.themes.cursor(opts)
+    ensure_backend()
+    if M.impl.themes and M.impl.themes.cursor then
+        return M.impl.themes.cursor(opts)
+    end
+    return opts or {}
+end
+
+-- ============================================================================
+-- Utility Functions
+-- ============================================================================
+
+-- Create entry display formatter (for link counts, icons, etc)
+-- @param spec table: display specification
+--   - separator: string
+--   - items: table of { width = number, remaining = boolean }
+-- @return function: displayer function
+function M.create_entry_display(spec)
+    ensure_backend()
+    if M.impl.create_entry_display then
+        return M.impl.create_entry_display(spec)
+    end
+    -- Fallback: simple formatter
+    return function(entry)
+        return entry.display or entry.value or tostring(entry)
+    end
+end
+
+-- Check if backend supports feature
+-- @param feature string: feature name
+-- @return boolean
+function M.supports(feature)
+    ensure_backend()
+    if M.impl.supports then
+        return M.impl.supports(feature)
+    end
+    return false
+end
+
+-- ============================================================================
+-- Backend-Agnostic Helper Functions
+-- ============================================================================
+
+-- Sort file list by filename or modification time
+-- @param files table: list of file paths
+-- @param sort_by string: "filename" | "modified"
+-- @return table: sorted file list
+function M.sort_files(files, sort_by)
+    if sort_by == "modified" then
+        table.sort(files, function(a, b)
+            return vim.fn.getftime(a) > vim.fn.getftime(b)
+        end)
+    else
+        table.sort(files, function(a, b)
+            return a > b
+        end)
+    end
+    return files
+end
+
+-- Filter files by extension
+-- @param files table: list of file paths
+-- @param extensions table: list of extensions (e.g., {".md", ".txt"})
+-- @return table: filtered file list
+function M.filter_by_extension(files, extensions)
+    if not extensions or #extensions == 0 then
+        return files
+    end
+
+    local ext_map = {}
+    for _, ext in ipairs(extensions) do
+        ext_map[ext] = true
+    end
+
+    local filtered = {}
+    for _, file in ipairs(files) do
+        local ext = file:match("^.+(%..+)$")
+        if ext and ext_map[ext] then
+            table.insert(filtered, file)
+        end
+    end
+
+    return filtered
+end
+
+-- Create relative path from absolute paths
+-- @param from string: source path
+-- @param to string: target path
+-- @return string: relative path
+function M.make_relative_path(from, to)
+    local sep = "/"
+
+    local from_parts = {}
+    for part in from:gmatch("([^" .. sep .. "]+)") do
+        table.insert(from_parts, part)
+    end
+
+    local to_parts = {}
+    for part in to:gmatch("([^" .. sep .. "]+)") do
+        table.insert(to_parts, part)
+    end
+
+    local i = 1
+    while i < #to_parts and i < #from_parts do
+        if to_parts[i] ~= from_parts[i] then
+            break
+        end
+        i = i + 1
+    end
+
+    local relative = ""
+    while i <= #to_parts or i <= #from_parts do
+        if i <= #to_parts then
+            if relative == "" then
+                relative = to_parts[i]
+            else
+                relative = relative .. sep .. to_parts[i]
+            end
+        end
+        if i <= #from_parts - 1 then
+            relative = ".." .. sep .. relative
+        end
+        i = i + 1
+    end
+
+    return relative
+end
+
+-- ============================================================================
+-- Validation
+-- ============================================================================
+
+-- Validate that a backend implementation has required functions
+function M.validate_backend(impl)
+    local required = {
+        "find_files",
+        "live_grep",
+        "custom_picker",
+        "actions",
+    }
+
+    for _, fn_name in ipairs(required) do
+        if not impl[fn_name] then
+            return false,
+                string.format("Backend missing required function: %s", fn_name)
+        end
+    end
+
+    local required_actions = {
+        "select_default",
+        "close",
+        "yank_selection",
+        "paste_selection",
+        "get_selection",
+        "get_current_line",
+    }
+
+    for _, action_name in ipairs(required_actions) do
+        if not impl.actions[action_name] then
+            return false,
+                string.format(
+                    "Backend missing required action: actions.%s",
+                    action_name
+                )
+        end
+    end
+
+    return true
+end
+
+return M

--- a/lua/telekasten/picker/snacks.lua
+++ b/lua/telekasten/picker/snacks.lua
@@ -1,0 +1,442 @@
+-- lua/telekasten/picker/snacks.lua
+-- Snacks.nvim backend implementation for telekasten picker abstraction
+
+local M = {}
+
+-- Lazy-loaded snacks module
+local snacks_loaded = false
+local snacks
+
+-- Load snacks
+local function ensure_snacks()
+    if snacks_loaded then
+        return true
+    end
+
+    local ok, s = pcall(require, "snacks")
+    if not ok then
+        error(
+            "snacks.nvim is not installed. Please install snacks.nvim or use a different picker backend."
+        )
+    end
+
+    snacks = s
+    snacks_loaded = true
+    return true
+end
+
+-- Backend configuration
+M.config = {}
+
+function M.setup(opts)
+    ensure_snacks()
+    M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+end
+
+-- ============================================================================
+-- Helper Functions
+-- ============================================================================
+
+-- Store current selection for compatibility
+M._current_selection = nil
+M._current_line = nil
+
+-- Convert telekasten attach_mappings to snacks format
+local function convert_mappings(attach_mappings)
+    if not attach_mappings then
+        return nil
+    end
+
+    local actions_obj = {}
+    local map_fn = function(mode, key, action_fn)
+        actions_obj[key] = action_fn
+    end
+
+    -- Call attach_mappings with mock
+    attach_mappings(actions_obj, map_fn)
+
+    -- Convert to snacks actions format
+    local snacks_actions = {}
+    for key, action_fn in pairs(actions_obj) do
+        snacks_actions[key] = function(picker_obj)
+            -- Store selection
+            M._current_selection = picker_obj:current()
+            M._current_line = picker_obj:current()
+
+            -- Create mock prompt_bufnr
+            local mock_bufnr = vim.api.nvim_get_current_buf()
+
+            -- Call the action
+            action_fn(mock_bufnr)
+        end
+    end
+
+    return snacks_actions
+end
+
+-- Format entry for display
+local function format_entry(entry, opts)
+    if type(entry) == "string" then
+        return entry
+    end
+
+    if entry.display then
+        if type(entry.display) == "function" then
+            local display_result = entry.display(entry)
+            if type(display_result) == "string" then
+                return display_result
+            elseif type(display_result) == "table" then
+                return display_result[1] or tostring(entry)
+            end
+        else
+            return entry.display
+        end
+    end
+
+    return entry.value or tostring(entry)
+end
+
+-- ============================================================================
+-- Core Picker Implementations
+-- ============================================================================
+
+function M.find_files(opts)
+    ensure_snacks()
+    opts = opts or {}
+
+    -- For simple cases, use snacks' built-in files
+    if not opts.show_link_counts and not opts.search_pattern then
+        local snacks_opts = {
+            prompt = opts.prompt_title or "Find Files",
+            cwd = opts.cwd,
+            input = opts.default_text,
+        }
+
+        -- Convert actions
+        if opts.attach_mappings then
+            snacks_opts.actions = convert_mappings(opts.attach_mappings)
+        end
+
+        return snacks.picker.pick("files", snacks_opts)
+    end
+
+    -- For complex cases, scan and format manually
+    local scan = require("plenary.scandir")
+
+    local scan_opts = {
+        search_pattern = opts.search_pattern,
+        depth = opts.search_depth,
+    }
+
+    local file_list = scan.scan_dir(opts.cwd, scan_opts)
+
+    -- Filter by extension
+    if opts.filter_extensions then
+        local filtered = {}
+        for _, file in ipairs(file_list) do
+            local ext = file:match("^.+(%..+)$")
+            for _, allowed_ext in ipairs(opts.filter_extensions) do
+                if ext == allowed_ext then
+                    table.insert(filtered, file)
+                    break
+                end
+            end
+        end
+        file_list = filtered
+    end
+
+    -- Sort files
+    if opts.sort == "modified" then
+        table.sort(file_list, function(a, b)
+            return vim.fn.getftime(a) > vim.fn.getftime(b)
+        end)
+    else
+        table.sort(file_list, function(a, b)
+            return a > b
+        end)
+    end
+
+    -- Format entries with link counts if needed
+    local formatted_entries = {}
+    for _, file in ipairs(file_list) do
+        local display = file:gsub(opts.cwd .. "/", "")
+
+        if opts.show_link_counts and opts.link_counts then
+            local nlinks = opts.link_counts.link_counts[file] or 0
+            local nbacks = opts.link_counts.backlink_counts[file] or 0
+            display = string.format("L%-3d B%-3d %s", nlinks, nbacks, display)
+        end
+
+        table.insert(formatted_entries, {
+            text = display,
+            file = file,
+        })
+    end
+
+    local snacks_opts = {
+        prompt = opts.prompt_title or "Find Files",
+        format = "file",
+    }
+
+    -- Convert actions
+    if opts.attach_mappings then
+        snacks_opts.actions = convert_mappings(opts.attach_mappings)
+    end
+
+    return snacks.picker.pick(formatted_entries, snacks_opts)
+end
+
+function M.live_grep(opts)
+    ensure_snacks()
+    opts = opts or {}
+
+    local snacks_opts = {
+        prompt = opts.prompt_title or "Live Grep",
+        cwd = opts.cwd,
+        input = opts.default_text or "",
+    }
+
+    -- Convert actions
+    if opts.attach_mappings then
+        snacks_opts.actions = convert_mappings(opts.attach_mappings)
+    end
+
+    return snacks.picker.pick("grep", snacks_opts)
+end
+
+function M.custom_picker(opts)
+    ensure_snacks()
+    opts = opts or {}
+
+    local results = opts.results or {}
+
+    -- Format entries using entry_maker if provided
+    local formatted_entries = {}
+    if opts.entry_maker then
+        for _, item in ipairs(results) do
+            local entry = opts.entry_maker(item)
+            local display = format_entry(entry, opts)
+            table.insert(formatted_entries, {
+                text = display,
+                value = entry.value,
+                ordinal = entry.ordinal or display,
+            })
+        end
+    else
+        for _, item in ipairs(results) do
+            table.insert(formatted_entries, {
+                text = tostring(item),
+                value = item,
+            })
+        end
+    end
+
+    local snacks_opts = {
+        prompt = opts.prompt_title or "Select",
+    }
+
+    -- Apply theme-like layout
+    if opts.theme == "dropdown" then
+        snacks_opts.layout = {
+            height = 0.4,
+            width = 0.6,
+        }
+    elseif opts.theme == "ivy" then
+        snacks_opts.layout = {
+            height = 0.4,
+            position = "bottom",
+        }
+    elseif opts.theme == "cursor" then
+        snacks_opts.layout = {
+            height = 0.3,
+            width = 0.3,
+            position = "center",
+        }
+    end
+
+    -- Convert actions
+    if opts.attach_mappings then
+        snacks_opts.actions = convert_mappings(opts.attach_mappings)
+    end
+
+    return snacks.picker.pick(formatted_entries, snacks_opts)
+end
+
+-- ============================================================================
+-- Actions
+-- ============================================================================
+
+M.actions = {}
+
+function M.actions.select_default(callback)
+    return function(picker_obj)
+        if callback then
+            -- Store selection
+            M._current_selection = picker_obj:current()
+
+            -- Create mock prompt_bufnr
+            local mock_bufnr = vim.api.nvim_get_current_buf()
+            callback(mock_bufnr)
+        else
+            -- Default behavior
+            local item = picker_obj:current()
+            if item and item.file then
+                vim.cmd("edit " .. item.file)
+            elseif item and item.text then
+                vim.cmd("edit " .. item.text)
+            end
+        end
+    end
+end
+
+function M.actions.close(opts)
+    opts = opts or {}
+    return function(picker_obj)
+        picker_obj:close()
+
+        -- Erase file if specified
+        if opts.erase and opts.erase_file then
+            if vim.fn.filereadable(opts.erase_file) == 1 then
+                vim.fn.delete(opts.erase_file)
+            end
+        end
+    end
+end
+
+function M.actions.yank_selection(get_text_fn)
+    return function(picker_obj)
+        local item = picker_obj:current()
+        if not item then
+            return
+        end
+
+        M._current_selection = item
+
+        -- Create mock entry
+        local mock_entry = {
+            value = item.file or item.text or item.value,
+            filename = item.file or item.text,
+        }
+
+        local text = get_text_fn(mock_entry)
+        vim.fn.setreg('"', text)
+        print("yanked " .. text)
+    end
+end
+
+function M.actions.paste_selection(get_text_fn, insert_after)
+    return function(picker_obj)
+        local item = picker_obj:current()
+        if not item then
+            return
+        end
+
+        picker_obj:close()
+
+        M._current_selection = item
+
+        -- Create mock entry
+        local mock_entry = {
+            value = item.file or item.text or item.value,
+            filename = item.file or item.text,
+        }
+
+        local text = get_text_fn(mock_entry)
+        vim.api.nvim_put({ text }, "", true, true)
+
+        if insert_after then
+            vim.api.nvim_feedkeys("A", "m", false)
+        end
+    end
+end
+
+function M.actions.get_selection()
+    -- Return mock entry with stored selection
+    if M._current_selection then
+        return {
+            value = M._current_selection.file
+                or M._current_selection.text
+                or M._current_selection.value,
+            filename = M._current_selection.file or M._current_selection.text,
+        }
+    end
+    return nil
+end
+
+function M.actions.get_current_line()
+    return M._current_line or ""
+end
+
+-- ============================================================================
+-- Themes
+-- ============================================================================
+
+M.themes = {}
+
+function M.themes.dropdown(opts)
+    opts = opts or {}
+    return vim.tbl_deep_extend("force", {
+        layout = {
+            height = 0.4,
+            width = 0.6,
+            position = "center",
+        },
+    }, opts)
+end
+
+function M.themes.ivy(opts)
+    opts = opts or {}
+    return vim.tbl_deep_extend("force", {
+        layout = {
+            height = 0.4,
+            position = "bottom",
+        },
+    }, opts)
+end
+
+function M.themes.cursor(opts)
+    opts = opts or {}
+    return vim.tbl_deep_extend("force", {
+        layout = {
+            height = 0.3,
+            width = 0.3,
+            position = "center",
+        },
+    }, opts)
+end
+
+-- ============================================================================
+-- Utilities
+-- ============================================================================
+
+function M.create_entry_display(spec)
+    -- Snacks doesn't have telescope's entry_display
+    -- Return a simple formatter function
+    return function(entry)
+        if type(entry) == "table" and entry.display then
+            if type(entry.display) == "function" then
+                return entry.display(entry)
+            else
+                return entry.display
+            end
+        end
+        return tostring(entry.value or entry)
+    end
+end
+
+function M.supports(feature)
+    local supported = {
+        "live_grep",
+        "themes",
+    }
+
+    for _, f in ipairs(supported) do
+        if f == feature then
+            return true
+        end
+    end
+
+    return false
+end
+
+return M

--- a/lua/telekasten/picker/snacks_test.lua
+++ b/lua/telekasten/picker/snacks_test.lua
@@ -1,0 +1,310 @@
+-- lua/telekasten/picker/snacks_test.lua
+-- Test functions for snacks picker (using taglinks testing pattern)
+
+local M = {}
+
+local function _print_debug(x, prefix)
+    prefix = prefix or ""
+    for k, v in pairs(x) do
+        print(prefix .. k .. ": " .. tostring(v))
+    end
+end
+
+local function _expect(x, y, context)
+    for k, v in pairs(y) do
+        if x[k] ~= v then
+            if context then
+                print("Test: " .. context)
+            end
+            print("expected:")
+            _print_debug(y, "  ")
+            print("got:")
+            _print_debug(x, "  ")
+            assert(false, "Test failed: " .. (context or "unknown"))
+        end
+    end
+end
+
+-- Test backend structure
+M._test_backend_structure = function()
+    local snacks = require("telekasten.picker.snacks")
+
+    -- Test required functions exist
+    assert(snacks.find_files ~= nil, "find_files missing")
+    assert(snacks.live_grep ~= nil, "live_grep missing")
+    assert(snacks.custom_picker ~= nil, "custom_picker missing")
+    assert(snacks.setup ~= nil, "setup missing")
+
+    -- Test actions exist
+    assert(snacks.actions ~= nil, "actions table missing")
+    assert(
+        snacks.actions.select_default ~= nil,
+        "select_default action missing"
+    )
+    assert(snacks.actions.close ~= nil, "close action missing")
+    assert(
+        snacks.actions.yank_selection ~= nil,
+        "yank_selection action missing"
+    )
+    assert(
+        snacks.actions.paste_selection ~= nil,
+        "paste_selection action missing"
+    )
+    assert(snacks.actions.get_selection ~= nil, "get_selection action missing")
+    assert(
+        snacks.actions.get_current_line ~= nil,
+        "get_current_line action missing"
+    )
+
+    -- Test themes exist
+    assert(snacks.themes ~= nil, "themes table missing")
+    assert(snacks.themes.dropdown ~= nil, "dropdown theme missing")
+    assert(snacks.themes.ivy ~= nil, "ivy theme missing")
+    assert(snacks.themes.cursor ~= nil, "cursor theme missing")
+
+    print("✓ Backend structure tests passed")
+end
+
+-- Test actions functionality
+M._test_actions = function()
+    local snacks = require("telekasten.picker.snacks")
+
+    -- Test get_selection with no selection
+    snacks._current_selection = nil
+    local result = snacks.actions.get_selection()
+    assert(result == nil, "get_selection should return nil when no selection")
+
+    -- Test get_selection with file selection
+    snacks._current_selection = {
+        file = "/test/path.md",
+        text = "test text",
+    }
+    result = snacks.actions.get_selection()
+    _expect(result, {
+        value = "/test/path.md",
+        filename = "/test/path.md",
+    }, "get_selection with file")
+
+    -- Test get_selection with text only
+    snacks._current_selection = {
+        text = "just text",
+        value = "some value",
+    }
+    result = snacks.actions.get_selection()
+    assert(result.value == "just text", "get_selection should prefer text")
+
+    -- Test get_current_line
+    snacks._current_line = nil
+    result = snacks.actions.get_current_line()
+    assert(result == "", "get_current_line should return empty string when nil")
+
+    snacks._current_line = "test line"
+    result = snacks.actions.get_current_line()
+    assert(result == "test line", "get_current_line should return stored line")
+
+    -- Cleanup
+    snacks._current_selection = nil
+    snacks._current_line = nil
+
+    print("✓ Actions tests passed")
+end
+
+-- Test themes configuration
+M._test_themes = function()
+    local snacks = require("telekasten.picker.snacks")
+
+    -- Test dropdown theme
+    local dropdown = snacks.themes.dropdown()
+    _expect(dropdown.layout, {
+        height = 0.4,
+        width = 0.6,
+        position = "center",
+    }, "dropdown theme layout")
+
+    -- Test ivy theme
+    local ivy = snacks.themes.ivy()
+    _expect(ivy.layout, {
+        height = 0.4,
+        position = "bottom",
+    }, "ivy theme layout")
+
+    -- Test cursor theme
+    local cursor = snacks.themes.cursor()
+    _expect(cursor.layout, {
+        height = 0.3,
+        width = 0.3,
+        position = "center",
+    }, "cursor theme layout")
+
+    -- Test theme merging
+    local custom_dropdown = snacks.themes.dropdown({
+        layout = { width = 0.8 },
+    })
+    assert(
+        custom_dropdown.layout.width == 0.8,
+        "theme should merge custom width"
+    )
+    assert(
+        custom_dropdown.layout.height == 0.4,
+        "theme should keep default height"
+    )
+
+    print("✓ Theme tests passed")
+end
+
+-- Test utilities
+M._test_utilities = function()
+    local snacks = require("telekasten.picker.snacks")
+
+    -- Test supports
+    assert(snacks.supports("live_grep") == true, "should support live_grep")
+    assert(snacks.supports("themes") == true, "should support themes")
+    assert(
+        snacks.supports("media_preview") == false,
+        "should not support media_preview"
+    )
+    assert(
+        snacks.supports("nonexistent") == false,
+        "should not support unknown feature"
+    )
+
+    -- Test create_entry_display
+    local formatter = snacks.create_entry_display({})
+    assert(
+        type(formatter) == "function",
+        "create_entry_display should return function"
+    )
+
+    -- Test formatter with string
+    local result = formatter("test string")
+    assert(result == "test string", "formatter should handle strings")
+
+    -- Test formatter with table
+    result = formatter({ display = "display text", value = "value" })
+    assert(result == "display text", "formatter should use display field")
+
+    result = formatter({ value = "some value" })
+    assert(result == "some value", "formatter should fall back to value field")
+
+    print("✓ Utility tests passed")
+end
+
+-- Test backend validation
+M._test_validation = function()
+    local snacks = require("telekasten.picker.snacks")
+    local picker_init = require("telekasten.picker.init")
+
+    local valid, err = picker_init.validate_backend(snacks)
+    assert(
+        valid == true,
+        "snacks backend should pass validation: " .. (err or "")
+    )
+
+    print("✓ Validation tests passed")
+end
+
+-- Test plenary scandir integration
+M._test_plenary_integration = function()
+    local has_plenary, scandir = pcall(require, "plenary.scandir")
+    assert(has_plenary, "plenary.scandir should be available")
+    assert(scandir.scan_dir ~= nil, "scan_dir function should exist")
+
+    -- Create temp test directory
+    local test_dir = vim.fn.tempname()
+    vim.fn.mkdir(test_dir, "p")
+
+    -- Create test files
+    local test_files = {
+        "note1.md",
+        "note2.md",
+        "note3.txt",
+    }
+
+    for _, filename in ipairs(test_files) do
+        local path = test_dir .. "/" .. filename
+        local file = io.open(path, "w")
+        if file then
+            file:write("test content\n")
+            file:close()
+        end
+    end
+
+    -- Test scanning
+    local files = scandir.scan_dir(test_dir, {
+        search_pattern = ".*%.md$",
+    })
+
+    assert(files ~= nil, "scan_dir should return results")
+    assert(#files == 2, "should find 2 .md files, found " .. #files)
+
+    -- Cleanup
+    vim.fn.delete(test_dir, "rf")
+
+    print("✓ Plenary integration tests passed")
+end
+
+-- Test picker initialization
+M._test_picker_init = function()
+    local picker_init = require("telekasten.picker.init")
+
+    -- Test setup with snacks
+    picker_init.setup("snacks", {})
+    assert(
+        picker_init.get_backend() == "snacks",
+        "backend should be set to snacks"
+    )
+
+    -- Test that functions are forwarded
+    assert(picker_init.find_files ~= nil, "find_files should be forwarded")
+    assert(picker_init.live_grep ~= nil, "live_grep should be forwarded")
+    assert(
+        picker_init.custom_picker ~= nil,
+        "custom_picker should be forwarded"
+    )
+
+    print("✓ Picker initialization tests passed")
+end
+
+-- Main test runner
+M._testme = function()
+    print("\n=== Running Snacks Picker Tests ===\n")
+
+    local tests = {
+        { name = "Backend Structure", fn = M._test_backend_structure },
+        { name = "Actions", fn = M._test_actions },
+        { name = "Themes", fn = M._test_themes },
+        { name = "Utilities", fn = M._test_utilities },
+        { name = "Validation", fn = M._test_validation },
+        { name = "Plenary Integration", fn = M._test_plenary_integration },
+        { name = "Picker Initialization", fn = M._test_picker_init },
+    }
+
+    local passed = 0
+    local failed = 0
+
+    for _, test in ipairs(tests) do
+        local ok, err = pcall(test.fn)
+        if ok then
+            passed = passed + 1
+        else
+            failed = failed + 1
+            print("✗ " .. test.name .. " FAILED:")
+            print("  " .. tostring(err))
+        end
+    end
+
+    print("\n=== Test Summary ===")
+    print(string.format("Passed: %d", passed))
+    print(string.format("Failed: %d", failed))
+    print(string.format("Total:  %d", passed + failed))
+
+    if failed == 0 then
+        print("\n✓ All tests passed!")
+    else
+        print("\n✗ Some tests failed")
+    end
+
+    return failed == 0
+end
+
+return M

--- a/lua/telekasten/picker/telescope.lua
+++ b/lua/telekasten/picker/telescope.lua
@@ -1,0 +1,418 @@
+-- lua/telekasten/picker/telescope.lua
+-- Telescope backend implementation for telekasten picker abstraction
+
+local M = {}
+
+-- Lazy-loaded telescope modules
+local telescope_loaded = false
+local builtin, actions, action_state, action_set, pickers, finders, conf
+local previewers, make_entry, entry_display, sorters, themes, utils
+
+-- Load telescope modules
+local function ensure_telescope()
+    if telescope_loaded then
+        return true
+    end
+
+    local ok, _ = pcall(require, "telescope")
+    if not ok then
+        error(
+            "Telescope is not installed. Please install telescope.nvim or use a different picker backend."
+        )
+    end
+
+    builtin = require("telescope.builtin")
+    actions = require("telescope.actions")
+    action_state = require("telescope.actions.state")
+    action_set = require("telescope.actions.set")
+    pickers = require("telescope.pickers")
+    finders = require("telescope.finders")
+    conf = require("telescope.config").values
+    previewers = require("telescope.previewers")
+    make_entry = require("telescope.make_entry")
+    entry_display = require("telescope.pickers.entry_display")
+    sorters = require("telescope.sorters")
+    themes = require("telescope.themes")
+    utils = require("telescope.utils")
+
+    telescope_loaded = true
+    return true
+end
+
+-- Backend configuration
+M.config = {}
+
+function M.setup(opts)
+    ensure_telescope()
+    M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+end
+
+-- ============================================================================
+-- Core Picker Implementations
+-- ============================================================================
+
+function M.find_files(opts)
+    ensure_telescope()
+    opts = opts or {}
+
+    -- Use builtin find_files for simple cases
+    if not opts.show_link_counts and not opts.preview_type then
+        local telescope_opts = {
+            prompt_title = opts.prompt_title or "Find Files",
+            cwd = opts.cwd,
+            default_text = opts.default_text,
+            attach_mappings = opts.attach_mappings,
+            find_command = opts.find_command,
+        }
+
+        return builtin.find_files(telescope_opts)
+    end
+
+    -- For complex cases, use custom picker with plenary scan
+    local scan = require("plenary.scandir")
+    local Path = require("plenary.path")
+
+    local scan_opts = {
+        search_pattern = opts.search_pattern,
+        depth = opts.search_depth,
+    }
+
+    local file_list = scan.scan_dir(opts.cwd, scan_opts)
+
+    -- Filter by extension if needed
+    if opts.filter_extensions then
+        local filtered = {}
+        for _, file in ipairs(file_list) do
+            local ext = file:match("^.+(%..+)$")
+            for _, allowed_ext in ipairs(opts.filter_extensions) do
+                if ext == allowed_ext then
+                    table.insert(filtered, file)
+                    break
+                end
+            end
+        end
+        file_list = filtered
+    end
+
+    -- Sort files
+    if opts.sort == "modified" then
+        table.sort(file_list, function(a, b)
+            return vim.fn.getftime(a) > vim.fn.getftime(b)
+        end)
+    else
+        table.sort(file_list, function(a, b)
+            return a > b
+        end)
+    end
+
+    -- Create entry maker
+    local function make_file_entry(entry)
+        local display_fn
+
+        if opts.show_link_counts then
+            -- Custom display with link counts
+            local displayer = entry_display.create({
+                separator = "",
+                items = {
+                    { width = 4 },
+                    { width = 4 },
+                    { remaining = true },
+                },
+            })
+
+            display_fn = function(e)
+                local display = e.value:gsub(opts.cwd .. "/", "")
+                local display_with_icon, hl_group =
+                    utils.transform_devicons(e.value, display, false)
+
+                -- Get link counts (passed via opts.link_counts)
+                local nlinks = opts.link_counts
+                        and opts.link_counts.link_counts[e.value]
+                    or 0
+                local nbacks = opts.link_counts
+                        and opts.link_counts.backlink_counts[e.value]
+                    or 0
+
+                return displayer({
+                    {
+                        "L" .. tostring(nlinks),
+                        function()
+                            return {
+                                { { 0, 1 }, "tkTagSep" },
+                                { { 1, 3 }, "tkTag" },
+                            }
+                        end,
+                    },
+                    {
+                        "B" .. tostring(nbacks),
+                        function()
+                            return {
+                                { { 0, 1 }, "tkTagSep" },
+                                { { 1, 3 }, "DevIconMd" },
+                            }
+                        end,
+                    },
+                    {
+                        display_with_icon,
+                        function()
+                            return hl_group and { { { 1, 3 }, hl_group } } or {}
+                        end,
+                    },
+                })
+            end
+        else
+            -- Simple display with devicons
+            display_fn = function(e)
+                local display = e.value:gsub(opts.cwd .. "/", "")
+                local display_with_icon, hl_group =
+                    utils.transform_devicons(e.value, display, false)
+
+                if hl_group then
+                    return display_with_icon, { { { 1, 3 }, hl_group } }
+                else
+                    return display_with_icon
+                end
+            end
+        end
+
+        return {
+            value = entry,
+            path = entry,
+            ordinal = entry,
+            display = display_fn,
+        }
+    end
+
+    -- Select previewer
+    local previewer_fn = conf.file_previewer(opts)
+    if opts.preview_type == "media" then
+        -- Use media previewer if configured
+        previewer_fn = M.get_media_previewer(opts)
+    end
+
+    local picker = pickers.new(opts, {
+        prompt_title = opts.prompt_title or "Find Files",
+        finder = finders.new_table({
+            results = file_list,
+            entry_maker = make_file_entry,
+        }),
+        sorter = conf.generic_sorter(opts),
+        previewer = previewer_fn,
+        attach_mappings = opts.attach_mappings,
+    })
+
+    return picker:find()
+end
+
+function M.live_grep(opts)
+    ensure_telescope()
+    opts = opts or {}
+
+    local telescope_opts = {
+        prompt_title = opts.prompt_title or "Live Grep",
+        cwd = opts.cwd,
+        search_dirs = opts.search_dirs,
+        default_text = opts.default_text,
+        attach_mappings = opts.attach_mappings,
+        find_command = opts.find_command,
+    }
+
+    return builtin.live_grep(telescope_opts)
+end
+
+function M.custom_picker(opts)
+    ensure_telescope()
+    opts = opts or {}
+
+    -- Apply theme if specified
+    if opts.theme then
+        if opts.theme == "dropdown" then
+            opts = vim.tbl_deep_extend(
+                "force",
+                themes.get_dropdown(opts.theme_opts or {}),
+                opts
+            )
+        elseif opts.theme == "ivy" then
+            opts = vim.tbl_deep_extend(
+                "force",
+                themes.get_ivy(opts.theme_opts or {}),
+                opts
+            )
+        elseif opts.theme == "cursor" then
+            opts = vim.tbl_deep_extend(
+                "force",
+                themes.get_cursor(opts.theme_opts or {}),
+                opts
+            )
+        end
+    end
+
+    local picker = pickers.new(opts, {
+        prompt_title = opts.prompt_title or "Select",
+        finder = finders.new_table({
+            results = opts.results or {},
+            entry_maker = opts.entry_maker or function(entry)
+                return {
+                    value = entry,
+                    display = tostring(entry),
+                    ordinal = tostring(entry),
+                }
+            end,
+        }),
+        sorter = conf.generic_sorter(opts),
+        previewer = opts.previewer,
+        attach_mappings = opts.attach_mappings,
+    })
+
+    return picker:find()
+end
+
+-- ============================================================================
+-- Media Previewer
+-- ============================================================================
+
+function M.get_media_previewer(opts)
+    ensure_telescope()
+
+    -- Determine preview command based on configuration
+    local preview_cmd = ""
+    local media_previewer = opts.media_previewer or "telescope-media-files"
+
+    if media_previewer == "telescope-media-files" then
+        local base_dir = debug.getinfo(1, "S").source:match("@?(.*/)")
+        preview_cmd = base_dir
+            .. "../../../telescope-media-files.nvim/scripts/vimg"
+    elseif media_previewer == "catimg-previewer" then
+        preview_cmd = "catimg-previewer"
+    elseif media_previewer:match("^viu%-previewer") then
+        preview_cmd = media_previewer
+    end
+
+    if vim.fn.executable(preview_cmd) == 0 then
+        return conf.file_previewer(opts)
+    end
+
+    return previewers.new_termopen_previewer({
+        get_command = function(entry)
+            local preview = opts.get_preview_window()
+            return {
+                preview_cmd,
+                entry.value,
+                preview.col,
+                preview.line + 1,
+                preview.width,
+                preview.height,
+            }
+        end,
+    })
+end
+
+-- ============================================================================
+-- Actions
+-- ============================================================================
+
+M.actions = {}
+
+function M.actions.select_default(callback)
+    return function(prompt_bufnr)
+        if callback then
+            callback(prompt_bufnr)
+        else
+            return action_set.select(prompt_bufnr, "default")
+        end
+    end
+end
+
+function M.actions.close(opts)
+    opts = opts or {}
+    return function(prompt_bufnr)
+        actions.close(prompt_bufnr)
+
+        -- Erase file if specified
+        if opts.erase and opts.erase_file then
+            if vim.fn.filereadable(opts.erase_file) == 1 then
+                vim.fn.delete(opts.erase_file)
+            end
+        end
+    end
+end
+
+function M.actions.yank_selection(get_text_fn)
+    return function(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        local text = get_text_fn(selection)
+        vim.fn.setreg('"', text)
+        print("yanked " .. text)
+    end
+end
+
+function M.actions.paste_selection(get_text_fn, insert_after)
+    return function(prompt_bufnr)
+        actions.close(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        local text = get_text_fn(selection)
+        vim.api.nvim_put({ text }, "", true, true)
+
+        if insert_after then
+            vim.api.nvim_feedkeys("A", "m", false)
+        end
+    end
+end
+
+function M.actions.get_selection()
+    return action_state.get_selected_entry()
+end
+
+function M.actions.get_current_line()
+    return action_state.get_current_line()
+end
+
+-- ============================================================================
+-- Themes
+-- ============================================================================
+
+M.themes = {}
+
+function M.themes.dropdown(opts)
+    ensure_telescope()
+    return themes.get_dropdown(opts or {})
+end
+
+function M.themes.ivy(opts)
+    ensure_telescope()
+    return themes.get_ivy(opts or {})
+end
+
+function M.themes.cursor(opts)
+    ensure_telescope()
+    return themes.get_cursor(opts or {})
+end
+
+-- ============================================================================
+-- Utilities
+-- ============================================================================
+
+function M.create_entry_display(spec)
+    ensure_telescope()
+    return entry_display.create(spec)
+end
+
+function M.supports(feature)
+    local supported = {
+        "media_preview",
+        "custom_entry_display",
+        "themes",
+        "live_grep",
+        "devicons",
+    }
+
+    for _, f in ipairs(supported) do
+        if f == feature then
+            return true
+        end
+    end
+
+    return false
+end
+
+return M

--- a/lua/telekasten/picker/telescope_test.lua
+++ b/lua/telekasten/picker/telescope_test.lua
@@ -1,0 +1,248 @@
+-- lua/telekasten/picker/telescope_test.lua
+-- Test functions for telescope picker (using taglinks testing pattern)
+
+local M = {}
+
+local function _print_debug(x, prefix)
+    prefix = prefix or ""
+    for k, v in pairs(x) do
+        print(prefix .. k .. ": " .. tostring(v))
+    end
+end
+
+local function _expect(x, y, context)
+    for k, v in pairs(y) do
+        if x[k] ~= v then
+            if context then
+                print("Test: " .. context)
+            end
+            print("expected:")
+            _print_debug(y, "  ")
+            print("got:")
+            _print_debug(x, "  ")
+            assert(false, "Test failed: " .. (context or "unknown"))
+        end
+    end
+end
+
+-- Test backend structure
+M._test_backend_structure = function()
+    local telescope = require("telekasten.picker.telescope")
+
+    -- Test required functions exist
+    assert(telescope.find_files ~= nil, "find_files missing")
+    assert(telescope.live_grep ~= nil, "live_grep missing")
+    assert(telescope.custom_picker ~= nil, "custom_picker missing")
+    assert(telescope.setup ~= nil, "setup missing")
+
+    -- Test actions exist
+    assert(telescope.actions ~= nil, "actions table missing")
+    assert(
+        telescope.actions.select_default ~= nil,
+        "select_default action missing"
+    )
+    assert(telescope.actions.close ~= nil, "close action missing")
+    assert(
+        telescope.actions.yank_selection ~= nil,
+        "yank_selection action missing"
+    )
+    assert(
+        telescope.actions.paste_selection ~= nil,
+        "paste_selection action missing"
+    )
+    assert(
+        telescope.actions.get_selection ~= nil,
+        "get_selection action missing"
+    )
+    assert(
+        telescope.actions.get_current_line ~= nil,
+        "get_current_line action missing"
+    )
+
+    -- Test themes exist
+    assert(telescope.themes ~= nil, "themes table missing")
+    assert(telescope.themes.dropdown ~= nil, "dropdown theme missing")
+    assert(telescope.themes.ivy ~= nil, "ivy theme missing")
+    assert(telescope.themes.cursor ~= nil, "cursor theme missing")
+
+    print("✓ Backend structure tests passed")
+end
+
+-- Test actions functionality
+M._test_actions = function()
+    local telescope = require("telekasten.picker.telescope")
+
+    -- Telescope actions are wrappers around telescope's action_state
+    -- We can verify they exist and are functions
+    assert(
+        type(telescope.actions.select_default) == "function",
+        "select_default should be a function"
+    )
+    assert(
+        type(telescope.actions.close) == "function",
+        "close should be a function"
+    )
+    assert(
+        type(telescope.actions.yank_selection) == "function",
+        "yank_selection should be a function"
+    )
+    assert(
+        type(telescope.actions.paste_selection) == "function",
+        "paste_selection should be a function"
+    )
+
+    -- Note: get_selection and get_current_line delegate to telescope's action_state
+    -- which requires a picker context, so we can't fully test them without a picker
+    assert(
+        type(telescope.actions.get_selection) == "function",
+        "get_selection should be a function"
+    )
+    assert(
+        type(telescope.actions.get_current_line) == "function",
+        "get_current_line should be a function"
+    )
+
+    print("✓ Actions tests passed")
+end
+
+-- Test themes configuration
+M._test_themes = function()
+    local telescope = require("telekasten.picker.telescope")
+
+    -- Test that theme functions exist and return tables
+    local dropdown = telescope.themes.dropdown()
+    assert(type(dropdown) == "table", "dropdown should return a table")
+
+    local ivy = telescope.themes.ivy()
+    assert(type(ivy) == "table", "ivy should return a table")
+
+    local cursor = telescope.themes.cursor()
+    assert(type(cursor) == "table", "cursor should return a table")
+
+    -- Test theme merging
+    local custom_dropdown = telescope.themes.dropdown({
+        custom_option = true,
+    })
+    assert(
+        type(custom_dropdown) == "table",
+        "custom dropdown should return a table"
+    )
+
+    print("✓ Theme tests passed")
+end
+
+-- Test utilities
+M._test_utilities = function()
+    local telescope = require("telekasten.picker.telescope")
+
+    -- Test supports - telescope has the most features
+    assert(telescope.supports("live_grep") == true, "should support live_grep")
+    assert(telescope.supports("themes") == true, "should support themes")
+    assert(
+        telescope.supports("media_preview") == true,
+        "should support media_preview"
+    )
+    assert(
+        telescope.supports("custom_entry_display") == true,
+        "should support custom_entry_display"
+    )
+    assert(telescope.supports("devicons") == true, "should support devicons")
+    assert(
+        telescope.supports("nonexistent") == false,
+        "should not support unknown feature"
+    )
+
+    -- Test create_entry_display
+    local formatter = telescope.create_entry_display({
+        separator = " ",
+        items = {
+            { width = 10 },
+            { remaining = true },
+        },
+    })
+    assert(
+        type(formatter) == "function",
+        "create_entry_display should return function"
+    )
+
+    print("✓ Utility tests passed")
+end
+
+-- Test backend validation
+M._test_validation = function()
+    local telescope = require("telekasten.picker.telescope")
+    local picker_init = require("telekasten.picker.init")
+
+    local valid, err = picker_init.validate_backend(telescope)
+    assert(
+        valid == true,
+        "telescope backend should pass validation: " .. (err or "")
+    )
+
+    print("✓ Validation tests passed")
+end
+
+-- Test picker initialization
+M._test_picker_init = function()
+    local picker_init = require("telekasten.picker.init")
+
+    -- Test setup with telescope
+    picker_init.setup("telescope", {})
+    assert(
+        picker_init.get_backend() == "telescope",
+        "backend should be set to telescope"
+    )
+
+    -- Test that functions are forwarded
+    assert(picker_init.find_files ~= nil, "find_files should be forwarded")
+    assert(picker_init.live_grep ~= nil, "live_grep should be forwarded")
+    assert(
+        picker_init.custom_picker ~= nil,
+        "custom_picker should be forwarded"
+    )
+
+    print("✓ Picker initialization tests passed")
+end
+
+-- Main test runner
+M._testme = function()
+    print("\n=== Running Telescope Picker Tests ===\n")
+
+    local tests = {
+        { name = "Backend Structure", fn = M._test_backend_structure },
+        { name = "Actions", fn = M._test_actions },
+        { name = "Themes", fn = M._test_themes },
+        { name = "Utilities", fn = M._test_utilities },
+        { name = "Validation", fn = M._test_validation },
+        { name = "Picker Initialization", fn = M._test_picker_init },
+    }
+
+    local passed = 0
+    local failed = 0
+
+    for _, test in ipairs(tests) do
+        local ok, err = pcall(test.fn)
+        if ok then
+            passed = passed + 1
+        else
+            failed = failed + 1
+            print("✗ " .. test.name .. " FAILED:")
+            print("  " .. tostring(err))
+        end
+    end
+
+    print("\n=== Test Summary ===")
+    print(string.format("Passed: %d", passed))
+    print(string.format("Failed: %d", failed))
+    print(string.format("Total:  %d", passed + failed))
+
+    if failed == 0 then
+        print("\n✓ All tests passed!")
+    else
+        print("\n✗ Some tests failed")
+    end
+
+    return failed == 0
+end
+
+return M

--- a/lua/telekasten/pickers.lua
+++ b/lua/telekasten/pickers.lua
@@ -1,44 +1,44 @@
+-- lua/telekasten/pickers.lua
+-- Updated to use picker abstraction
+
 local M = {}
 
-local actions = require("telescope.actions")
-local action_state = require("telescope.actions.state")
-local pickers = require("telescope.pickers")
-local finders = require("telescope.finders")
-local conf = require("telescope.config").values
+local picker = require("telekasten.picker")
 
 -- Pick between the various configured vaults
 function M.vaults(telekasten, opts)
     opts = opts or {}
     local vaults = telekasten.vaults
     local _vaults = {}
+
     for k, v in pairs(vaults) do
         table.insert(_vaults, { k, v })
     end
-    pickers
-        .new(opts, {
-            prompt_title = "Vaults",
-            finder = finders.new_table({
-                results = _vaults,
-                entry_maker = function(entry)
-                    return {
-                        value = entry,
-                        display = entry[1],
-                        ordinal = entry[1],
-                    }
-                end,
-            }),
-            sorter = conf.generic_sorter(opts),
-            attach_mappings = function(prompt_bufnr, map)
-                actions.select_default:replace(function()
-                    actions.close(prompt_bufnr)
-                    local selection = action_state.get_selected_entry()
-                    -- print(vim.inspect(selection))
-                    telekasten.chdir(selection.value[2])
-                end)
-                return true
-            end,
-        })
-        :find()
+
+    picker.custom_picker({
+        prompt_title = "Vaults",
+        results = _vaults,
+        entry_maker = function(entry)
+            return {
+                value = entry,
+                display = entry[1],
+                ordinal = entry[1],
+            }
+        end,
+        attach_mappings = function(prompt_bufnr, map)
+            map("i", "<cr>", function()
+                local selection = picker.actions.get_selection()
+                picker.actions.close()(prompt_bufnr)
+                telekasten.chdir(selection.value[2])
+            end)
+            map("n", "<cr>", function()
+                local selection = picker.actions.get_selection()
+                picker.actions.close()(prompt_bufnr)
+                telekasten.chdir(selection.value[2])
+            end)
+            return true
+        end,
+    })
 end
 
 return M

--- a/test_all.lua
+++ b/test_all.lua
@@ -1,0 +1,112 @@
+-- test_all.lua
+-- Run all tests using the taglinks testing pattern
+
+-- Colors for output
+local function red(str)
+    return "\27[31m" .. str .. "\27[0m"
+end
+
+local function green(str)
+    return "\27[32m" .. str .. "\27[0m"
+end
+
+local function yellow(str)
+    return "\27[33m" .. str .. "\27[0m"
+end
+
+print(yellow("\n=== Running Telekasten Tests ===\n"))
+
+local all_passed = true
+local results = {}
+
+-- Test taglinks
+print(yellow("Running taglinks tests..."))
+local taglinks = require("telekasten.utils.taglinks")
+local taglinks_ok, taglinks_err = pcall(taglinks._testme)
+if taglinks_ok then
+    print(green("✓ taglinks tests passed\n"))
+    table.insert(results, { name = "taglinks", passed = true })
+else
+    print(red("✗ taglinks tests failed:"))
+    print(red("  " .. tostring(taglinks_err) .. "\n"))
+    all_passed = false
+    table.insert(results, { name = "taglinks", passed = false })
+end
+
+-- Test telescope picker
+print(yellow("Running telescope picker tests..."))
+local telescope_test_ok, telescope_test_err = pcall(function()
+    local telescope_test = require("telekasten.picker.telescope_test")
+    return telescope_test._testme()
+end)
+if not telescope_test_ok then
+    print(red("✗ telescope picker tests failed:"))
+    print(red("  " .. tostring(telescope_test_err) .. "\n"))
+    all_passed = false
+    table.insert(results, { name = "telescope", passed = false })
+else
+    table.insert(results, { name = "telescope", passed = true })
+end
+
+-- Test fzf picker
+print(yellow("Running fzf picker tests..."))
+local fzf_test_ok, fzf_test_err = pcall(function()
+    local fzf_test = require("telekasten.picker.fzf_test")
+    return fzf_test._testme()
+end)
+if not fzf_test_ok then
+    print(red("✗ fzf picker tests failed:"))
+    print(red("  " .. tostring(fzf_test_err) .. "\n"))
+    all_passed = false
+    table.insert(results, { name = "fzf", passed = false })
+else
+    table.insert(results, { name = "fzf", passed = true })
+end
+
+-- Test snacks picker
+print(yellow("Running snacks picker tests..."))
+local snacks_test_ok, snacks_test_err = pcall(function()
+    local snacks_test = require("telekasten.picker.snacks_test")
+    return snacks_test._testme()
+end)
+if not snacks_test_ok then
+    print(red("✗ snacks picker tests failed:"))
+    print(red("  " .. tostring(snacks_test_err) .. "\n"))
+    all_passed = false
+    table.insert(results, { name = "snacks", passed = false })
+else
+    table.insert(results, { name = "snacks", passed = true })
+end
+
+-- Final summary
+print("\n" .. string.rep("=", 60))
+print(yellow("TEST SUMMARY"))
+print(string.rep("=", 60))
+
+local passed_count = 0
+local failed_count = 0
+for _, result in ipairs(results) do
+    if result.passed then
+        print(green("✓ " .. result.name))
+        passed_count = passed_count + 1
+    else
+        print(red("✗ " .. result.name))
+        failed_count = failed_count + 1
+    end
+end
+
+print(string.rep("-", 60))
+print(
+    string.format(
+        "%s: %d passed, %d failed, %d total",
+        all_passed and green("PASSED") or red("FAILED"),
+        passed_count,
+        failed_count,
+        passed_count + failed_count
+    )
+)
+print(string.rep("=", 60) .. "\n")
+
+if not all_passed then
+    os.exit(1)
+end


### PR DESCRIPTION
## Summary
This PR implements a robust picker abstraction layer that provides a unified interface for `telescope.nvim`, `fzf-lua`, and `snacks.nvim`.

### Key Changes
- **New Abstraction Layer**: Added `lua/telekasten/pickers_abstract.lua` which handles backend selection and provides a consistent API.
- **Backend-Agnostic Actions**: Introduced an `on_select` callback mechanism. This allows Telekasten to perform core actions (like opening a file or inserting a link) regardless of which picker is being used.
- **Refactored Telekasten Core**: Replaced all hardcoded Telescope calls in `lua/telekasten.lua` with the new abstract interface.
- **Path Resolution**: Implemented robust path resolution to ensure absolute paths are always used, fixing issues with template creation and link following in non-Telescope pickers.
- **Compatibility**: Maintained full Telescope support, including secondary keybindings (`<c-y>`, `<c-i>`) via `attach_mappings`.
- **Snacks.nvim Support**: Verified that all core features (Find Notes, Search, Templates, Link Following) work perfectly with the `snacks.nvim` picker.

### Why this is better
The previous attempt at abstraction was complex and partially broken. This new implementation is cleaner, easier to maintain, and focuses on a simple `on_select` callback that covers 90% of Telekasten's needs while still allowing for backend-specific extensions.