### PR TITLE
fix: Fixed Keymap Malfunction in FindAllTags (fixes #372)

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -3341,20 +3341,18 @@ local function FindAllTags(opts)
                 sorter = conf.generic_sorter(opts),
                 attach_mappings = apply_picker_mappings(
                     opts,
-                    function(prompt_bufnr, _)
-                        actions.select_default:replace(function()
-                            -- actions for insert tag, default action: search for tag
-                            local selection =
-                                action_state.get_selected_entry().value.tag
-                            local follow_opts = {
-                                follow_tag = selection,
-                                show_link_counts = false,
-                                templateDir = templateDir,
-                            }
-                            actions._close(prompt_bufnr, false)
-                            vim.schedule(function()
-                                FollowLink(follow_opts)
-                            end)
+                    function(prompt_bufnr)
+                        -- actions for insert tag, default action: search for tag
+                        local selection =
+                            action_state.get_selected_entry().value.tag
+                        local follow_opts = {
+                            follow_tag = selection,
+                            show_link_counts = false,
+                            templateDir = templateDir,
+                        }
+                        actions._close(prompt_bufnr, false)
+                        vim.schedule(function()
+                            FollowLink(follow_opts)
                         end)
                     end
                 ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

There was an unnecessary function layering in the call to the `apply_picker_mappings()` function, easily fixed by removing the additional function layer and duplicate keymap replacement. This fix has been tested and is working for me, with no additional <CR>/Enter input being needed to open the second picker.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #372 
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
