### PR TITLE
Add Periodic Enabled Flag To Enhance Multiple Vault Configs

### DIFF
--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -540,7 +540,7 @@ telekasten.setup({opts})
 
                                   *telekasten.settings.enable_create_new*
     enable_create_new: ~
-        Flag that determines if creating new notes with <C-n> in enabled when
+        Flag that determines if creating new notes with <C-n> is enabled when
         using the `find_notes` picker.
 
         Default: true
@@ -549,6 +549,17 @@ telekasten.setup({opts})
     -----------------------------------
     Valid keys for {opts.periodic}
     -----------------------------------
+
+                                            *telekasten.periodic.enabled*
+    enabled: ~
+        Flag that manages the availability of the periodic notes functionality.
+        If set to `false`, no periodic style notes will be created for this
+        vault, and any searching/detection functionality for these notes will
+        be deactivated. If periodic notes are or have been created manually,
+        they will not be tracked, or available in their corresponding telescope
+        pickers.
+
+        Default: `true`
 
                                             *telekasten.periodic.root*
     root: ~
@@ -1374,6 +1385,7 @@ of setups, including flat setups and many different nested setups.
 
 For specifics on the configuration settings, see: ~
     - |telekasten.periodic|
+    - |telekasten.periodic.enabled|
     - |telekasten.periodic.root|
     - |telekasten.periodic.kinds|
     - |telekasten.periodic.kinds.enabled|

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -769,6 +769,11 @@ local function GotoDate(opts)
         or config.options.journal_auto_open
 
     local pcfg = config.options.periodic
+    if not pcfg or pcfg.enabled == false then
+        tkutils.print_error("periodic notes are disabled")
+        return
+    end
+
     if not pcfg or not pcfg.kinds or not pcfg.kinds.daily then
         tkutils.print_error("periodic.daily is not configured")
         return

--- a/lua/telekasten/config.lua
+++ b/lua/telekasten/config.lua
@@ -53,6 +53,7 @@ function Config:get_defaults(home)
         auto_set_filetype = true,
         auto_set_syntax = true,
         periodic = {
+            enabled = true,
             root = _home,
             kinds = {
                 yearly = {

--- a/lua/telekasten/periodic.lua
+++ b/lua/telekasten/periodic.lua
@@ -261,7 +261,7 @@ function M.filename_pattern(periodic, kind, extension)
     end)
 
     pattern = pattern:gsub("{([%w_]+)}", function(key)
-        return token_meta[key] or ".*"
+        return token_meta[key].pattern or ".*"
     end)
 
     extension = extension or ""

--- a/lua/telekasten/periodic.lua
+++ b/lua/telekasten/periodic.lua
@@ -14,6 +14,7 @@ local vim = vim
 ---@field create_if_missing boolean
 
 ---@class PeriodicSpec
+---@field enabled boolean
 ---@field root string
 ---@field extension string
 ---@field kinds table<string, PeriodicKindSpec>
@@ -80,7 +81,7 @@ end
 local function build_detection_patterns(periodic)
     local patterns = {}
 
-    if not periodic or not periodic.kinds then
+    if not periodic or periodic.enabled == false or not periodic.kinds then
         return patterns
     end
 
@@ -136,6 +137,11 @@ end
 ---@return PeriodicConfig
 function M.normalize_periodic(periodic)
     periodic = periodic or {}
+
+    if periodic.enabled == nil then
+        periodic.enabled = true
+    end
+
     periodic.root = periodic.root or ""
     periodic.kinds = periodic.kinds or {}
 
@@ -158,12 +164,20 @@ function M.normalize_periodic(periodic)
         periodic.kinds[kind] = kcfg
     end
 
-    M.detection_patterns = build_detection_patterns(periodic)
+    if periodic.enabled == false then
+        M.detection_patterns = {}
+    else
+        M.detection_patterns = build_detection_patterns(periodic)
+    end
 
     return periodic
 end
 
 local function root_for_kind(periodic, kind)
+    if not periodic or periodic.enabled == false then
+        return nil
+    end
+
     local kcfg = periodic.kinds[kind]
     if not kcfg or kcfg.enabled == false then
         return nil
@@ -185,6 +199,10 @@ end
 ---@return string|nil root_dir
 ---@return string|nil sub_dir
 function M.build_path(periodic, kind, dinfo, extension)
+    if not periodic or periodic.enabled == false then
+        return nil, nil, nil, nil
+    end
+
     local kcfg = periodic.kinds[kind]
     if not kcfg or kcfg.enabled == false then
         return nil, nil, nil, nil
@@ -223,6 +241,10 @@ end
 ---@param extension string
 ---@return string|nil
 function M.filename_pattern(periodic, kind, extension)
+    if not periodic or periodic.enabled == false then
+        return nil
+    end
+
     local kcfg = periodic.kinds[kind]
     if not kcfg or kcfg.enabled == false then
         return nil

--- a/lua/telekasten/utils/definitions.lua
+++ b/lua/telekasten/utils/definitions.lua
@@ -27,6 +27,7 @@
 ---@field create_if_missing boolean
 
 ---@class PeriodicConfig
+---@field enabled boolean
 ---@field root string
 ---@field kinds table<PeriodicKind, PeriodicKindConfig>
 ---

--- a/lua/telekasten/utils/files.lua
+++ b/lua/telekasten/utils/files.lua
@@ -72,7 +72,7 @@ local function assemble_roots_specs(opts)
     add(config.options.home, "home")
 
     local pcfg = config.options.periodic
-    if pcfg then
+    if pcfg and pcfg.enabled ~= false then
         add(pcfg.root, "proot")
 
         if pcfg.kinds then
@@ -211,6 +211,11 @@ end
 local function check_if_periodic(title)
     local cal_monday = config.options.calendar_opts.calendar_monday
     local dateinfo = dateutils.calculate_dates(nil, cal_monday) -- sane default
+
+    local pcfg = config.options.periodic
+    if not pcfg or pcfg.enabled == false then
+        return false, false, false, false, false, dateinfo
+    end
 
     local is_daily = false
     local is_weekly = false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

I realized that there was no simple way to disable periodic notes in the current implementation, which is especially useful if setting up configurations for multiple vaults. As implementation of this particular feature doesn't fit with the current structure of the main branch, this will only be on the refact branch. Now the code will first check if the `enabled` option in the `periodic` opts table is true, and if it isn't it disables all periodic note functionality, including filename matching, searching, and creation.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes
- This PR is related to issue: #235 (technically it fixes it, but this is in the refact branch, so didn't want to close it as if the main branch had the fix as well)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
